### PR TITLE
Pylint fixes

### DIFF
--- a/Python/fastapi_server.py
+++ b/Python/fastapi_server.py
@@ -24,10 +24,8 @@ Created on December 23, 2024
         https://fastapi.tiangolo.com/
 """
 import os
-import sys
 import json
-import multipart
-import subprocess
+import multipart    # Used to get POST form data
 from pydantic import BaseModel
 from fastapi import FastAPI, BackgroundTasks, Request
 from fastapi.responses import FileResponse, RedirectResponse
@@ -74,9 +72,9 @@ async def middleware(request: Request, call_next):
 
 #### FAVICON ####################
 
-# Handle default browser request for /favicon.ico
 @api_app.get("/favicon.ico", include_in_schema=False)
 async def favicon():
+    """ Handle default browser request for /favicon.ico """
     return FileResponse(os.path.dirname(__file__) + '/static/favicon.ico')
 
 #### PLAYLISTS ####################
@@ -87,7 +85,7 @@ def load_presets():
         with open(PRESETS_FILE, "r") as f:
             return json.load(f)
     else:
-        oradio_log.error(f"Failed to open '{PRESETS_FILE}'")
+        oradio_log.error("Failed to open '%s'", PRESETS_FILE)
         return {"preset1": None, "preset2": None, "preset3": None}
 
 def store_presets(presets):
@@ -96,7 +94,7 @@ def store_presets(presets):
         with open(PRESETS_FILE, "w") as f:
             json.dump({"preset1": presets[0], "preset2": presets[1], "preset3": presets[2]}, f, indent=4)
     except IOError as ex_err:
-        oradio_log.error(f"Failed to write '{PRESETS_FILE}'. error: {ex_err}")
+        oradio_log.error("Failed to write '%s'. error: %s", PRESETS_FILE, ex_err)
 
 # Get mpd functions
 mpdcontrol = MPDControl()
@@ -130,7 +128,7 @@ async def playlists(request: Request):
     if request.method == "POST":
         # Load form data
         form_data = await request.form()
-        oradio_log.debug(f"form_data={form_data}")
+        oradio_log.debug("form_data=%s", form_data)
 
         # Get requested action
         action = form_data.get('action')
@@ -166,8 +164,8 @@ async def playlists(request: Request):
     # Return playlists page and available networks as context
     return templates.TemplateResponse(request=request, name="playlists.html", context=context)
 
-# Model for wifi network credentials
 class play(BaseModel):
+    """ Model for wifi network credentials """
     song: str = None
 
 # POST endpoint to play song
@@ -178,7 +176,7 @@ async def play_song(play: play):
     Handle connecting in background task, so the POST gets a response
     https://fastapi.tiangolo.com/tutorial/background-tasks/#using-backgroundtasks
     """
-    oradio_log.debug(f"play song: {play.song}")
+    oradio_log.debug("play song: '%s'", play.song)
     mpdcontrol.play_song(play.song)
 
     # Create message
@@ -188,7 +186,7 @@ async def play_song(play: play):
     message["state"] = MESSAGE_WEB_SERVICE_PLAYING_SONG
 
     # Put message in queue
-    oradio_log.debug(f"Send web service message: {message}")
+    oradio_log.debug("Send web service message: %s", message)
     api_app.state.message_queue.put(message)
 
 #### STATUS ####################
@@ -229,8 +227,9 @@ async def captiveportal(request: Request):
     # Return active portal page and available networks as context
     return templates.TemplateResponse(request=request, name="captiveportal.html", context=context)
 
-# Model for wifi network credentials
+
 class credentials(BaseModel):
+    """ # Model for wifi network credentials """
     ssid: str = None
     pswd: str = None
 
@@ -249,7 +248,7 @@ def wifi_connect_task(credentials: credentials):
     """
     Executes as background task
     """
-    oradio_log.debug(f"trying to connect to ssid={credentials.ssid}, pswd={credentials.pswd}")
+    oradio_log.debug("trying to connect to ssid=%s, pswd=%s", credentials.ssid, credentials.pswd)
     # Get access to wifi functions
     wifi = wifi_service(api_app.state.message_queue)
 

--- a/Python/fastapi_server.py
+++ b/Python/fastapi_server.py
@@ -182,7 +182,7 @@ async def play_song(play: play):
     # Create message
     message = {}
     message["type"]  = MESSAGE_WEB_SERVICE_TYPE
-#OMJ: Het type klopt niet? Het is geen web service state message, eeerder iets als info. Maar voor control is wel een state... 
+#OMJ: Het type klopt niet? Het is geen web service state message, eerder iets als info. Maar voor control is wel een state...
     message["state"] = MESSAGE_WEB_SERVICE_PLAYING_SONG
 
     # Put message in queue

--- a/Python/hw_serial_number_gen.py
+++ b/Python/hw_serial_number_gen.py
@@ -28,9 +28,9 @@ The script will:
 import os
 import json
 import sys
-import smbus2
 import subprocess
 from datetime import datetime
+import smbus2
 
 # Local Constants
 I2C_BUS = 1  # Typically 1 on modern Raspberry Pis

--- a/Python/led_control.py
+++ b/Python/led_control.py
@@ -21,7 +21,7 @@ Created on January 29, 2025
 
 import time
 import threading
-import RPi.GPIO as GPIO
+from RPi import GPIO
 from oradio_logging import oradio_log
 
 # Global constant for LED GPIO pins
@@ -57,7 +57,7 @@ class LEDControl:
     def turn_off_led(self, led_name):
         """Turns off a specific LED and stops its blinking if active."""
         if led_name not in LEDS:
-            oradio_log.error(f"Invalid LED name: {led_name}")
+            oradio_log.error("Invalid LED name: %s", led_name)
             return
         # Signal any blinking thread for this LED to stop
         self.blinking_leds[led_name] = False
@@ -66,16 +66,16 @@ class LEDControl:
             t.join(timeout=0.5)
             del self.blinking_threads[led_name]
         GPIO.output(LEDS[led_name], GPIO.HIGH)
-        oradio_log.debug(f"{led_name} turned off")
+        oradio_log.debug("%s turned off", led_name)
 
     def turn_on_led(self, led_name):
         """Turns on a specific LED (stops blinking if active)."""
         if led_name in LEDS:
             self.turn_off_led(led_name)  # Stop blinking if active
             GPIO.output(LEDS[led_name], GPIO.LOW)
-            oradio_log.debug(f"{led_name} turned on")
+            oradio_log.debug("%s turned on", led_name)
         else:
-            oradio_log.error(f"Invalid LED name: {led_name}")
+            oradio_log.error("Invalid LED name: %s", led_name)
 
     def turn_off_all_leds(self):
         """
@@ -92,7 +92,7 @@ class LEDControl:
         for led in LEDS.values():
             GPIO.output(led, GPIO.HIGH)
         oradio_log.debug("All LEDs turned off and blinking stopped")
-    
+
     def turn_on_led_with_delay(self, led_name, delay=3):
         """
         Turns on a specific LED and then turns it off after a delay.
@@ -102,18 +102,18 @@ class LEDControl:
             delay (float): Time in seconds before turning off the LED.
         """
         if led_name not in LEDS:
-            oradio_log.error(f"Invalid LED name: {led_name}")
+            oradio_log.error("Invalid LED name: %s", led_name)
             return
 
         # Stop any blinking for this LED and turn it on
         self.turn_off_led(led_name)
         GPIO.output(LEDS[led_name], GPIO.LOW)
-        oradio_log.debug(f"{led_name} turned on, will turn off after {delay} seconds")
+        oradio_log.debug("%s turned on, will turn off after %s seconds", led_name, delay)
 
         def delayed_off():
             time.sleep(delay)
             GPIO.output(LEDS[led_name], GPIO.HIGH)
-            oradio_log.debug(f"{led_name} turned off after {delay} seconds")
+            oradio_log.debug("%s turned off after %s seconds", led_name, delay)
 
         threading.Thread(target=delayed_off, daemon=True).start()
 
@@ -127,7 +127,7 @@ class LEDControl:
             cycle_time (float or None): Blink interval in seconds.
         """
         if led_name not in LEDS:
-            oradio_log.debug(f"Invalid LED name: {led_name}")
+            oradio_log.debug("Invalid LED name: %s", led_name)
             return
 
         # If no cycle time is provided, stop blinking
@@ -138,7 +138,7 @@ class LEDControl:
                 t.join(timeout=0.5)
                 del self.blinking_threads[led_name]
             GPIO.output(LEDS[led_name], GPIO.HIGH)
-            oradio_log.debug(f"{led_name} blinking stopped and turned off")
+            oradio_log.debug("%s blinking stopped and turned off", led_name)
             return
 
         # If a blinking thread is already running for this LED, stop it first.
@@ -167,7 +167,7 @@ class LEDControl:
         t = threading.Thread(target=blink, daemon=True)
         t.start()
         self.blinking_threads[led_name] = t
-        oradio_log.debug(f"{led_name} blinking started with cycle time: {cycle_time}s")
+        oradio_log.debug("%s blinking started with cycle time: %ss", led_name, cycle_time)
 
     def cleanup(self):
         """Cleans up GPIO on program exit."""
@@ -180,7 +180,7 @@ class LEDControl:
 # Entry point for stand-alone operation
 if __name__ == '__main__':
     print("\nStarting LED Control Standalone Test...\n")
-    
+
     # Instantiate LEDControl
     leds = LEDControl()
 

--- a/Python/mpd_control.py
+++ b/Python/mpd_control.py
@@ -99,7 +99,7 @@ class MPDControl:
                             self.last_status_error = None
                     except Exception as ex_err:
                         oradio_log.error("Error checking MPD status: %s", ex_err)
-                        self.last_status_error = str(e)
+                        self.last_status_error = str(ex_err)
             time.sleep(10)  # Check every 10 seconds
 
     def _ensure_client(self):

--- a/Python/mpd_control.py
+++ b/Python/mpd_control.py
@@ -173,7 +173,7 @@ class MPDControl:
             try:
                 self.client.stop()
                 oradio_log.debug("MPD stop")
-            except Exception as e:
+            except Exception as ex_err:
                 oradio_log.error("Error sending stop command: %s", ex_err)
 
     def next(self):
@@ -457,7 +457,7 @@ class MPDControl:
                 still_present = any(int(song.get("id", -1)) == inserted_song_id for song in playlist)
                 if still_present:
                     self.client.deleteid(inserted_song_id)
-                    oradio_log.debug(f"Deleted song id {inserted_song_id}")
+                    oradio_log.debug("Deleted song id %s", inserted_song_id)
                 else:
                     oradio_log.debug("Song id %s already removed from the playlist", inserted_song_id)
         except Exception as ex_err:

--- a/Python/oradio_const.py
+++ b/Python/oradio_const.py
@@ -86,4 +86,3 @@ VOLUME_MAXIMUM = 180
 MESSAGE_TYPE_VOLUME   = "Vol Control message"
 #OMJ: is MESSAGE_VOLUME_CHANGED niet een betere constante?
 MESSAGE_STATE_CHANGED = "Volume changed"
-

--- a/Python/oradio_logging.py
+++ b/Python/oradio_logging.py
@@ -27,12 +27,12 @@ Created on Januari 17, 2025
 import os
 import logging as python_logging
 from logging import DEBUG, INFO, WARNING, ERROR
-import concurrent_log_handler   
+import concurrent_log_handler
 from concurrent_log_handler import ConcurrentRotatingFileHandler
 from concurrent_log_handler.queue import setup_logging_queues
 
 ##### oradio modules ####################
-""" Functionality needed from other modules is loaded when needed to avoid circular import errors """
+# Functionality needed from other modules is loaded when needed to avoid circular import errors
 
 ##### GLOBAL constants ####################
 from oradio_const import *
@@ -81,7 +81,7 @@ class ThrottledFilter(python_logging.Filter):
 class RemoteMonitoringHandler(python_logging.Handler):
     """ Send error and warning messages to Oradio Remote Monitoring Service """
     def emit(self, record):
-        if record.levelno == WARNING or record.levelno == ERROR:
+        if record.levelno in (WARNING, ERROR):
             # Import here to avoid circular import
             from remote_monitoring import rms_service
             rms_service().send_message(record.levelname, record.message, f"{record.filename}:{record.lineno}")

--- a/Python/oradio_utils.py
+++ b/Python/oradio_utils.py
@@ -24,7 +24,6 @@ Created on Januari 17, 2025
         https://docs.python.org/3/howto/logging.html
         https://pypi.org/project/concurrent-log-handler/
 """
-import subprocess
 import urllib.request
 from subprocess import run
 from vcgencmd import Vcgencmd

--- a/Python/oradio_utils.py
+++ b/Python/oradio_utils.py
@@ -74,7 +74,7 @@ def get_throttled_state_rpi():
     flags = int( throttled_state.get('binary'),2) # convert binary string to integer
     last_four_bits = flags & 0xF
     if last_four_bits > 0:
-        # a new flag was set 
+        # a new flag was set
         throttled_state = True
     else:
         throttled_state = False
@@ -87,10 +87,10 @@ def run_shell_script(script):
     :param script (str) - shell command to execute
     Returns exit status and output of running the script
     """
-    oradio_log.debug(f"Runnning shell script: {script}")
-    process = subprocess.run(script, shell = True, capture_output = True, encoding = 'utf-8')
+    oradio_log.debug("Runnning shell script: %s", script)
+    process = run(script, shell = True, capture_output = True, encoding = 'utf-8')
     if process.returncode != 0:
-        oradio_log.error(f"shell script error: {process.stderr}")
+        oradio_log.error("shell script error: %s", process.stderr)
         return False, process.stderr
     return True, process.stdout
 

--- a/Python/play_system_sound.py
+++ b/Python/play_system_sound.py
@@ -84,24 +84,24 @@ class PlaySystemSound:
 #             print(f"ORADIO_DIR is set to: {ORADIO_DIR}")
 #             print(f"Expected path: {SOUND_FILES['StartUp']}")
             if not sound_file:
-                oradio_log.error(f"Invalid sound key: {sound_key}")
+                oradio_log.error("Invalid sound key: %s", sound_key)
                 return
 
             if not os.path.exists(sound_file):
-                oradio_log.debug(f"Sound file does not exist: {sound_file}")
+                oradio_log.debug("Sound file does not exist: %s", sound_file)
                 return
 
             command = ["aplay", "-D", self.audio_device, sound_file]
             subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            oradio_log.debug(f"System sound played successfully: {sound_file}")
+            oradio_log.debug("System sound played successfully: %s", sound_file)
 
-        except subprocess.CalledProcessError as e:
-            oradio_log.error(f"Error playing sound: {e}")
+        except subprocess.CalledProcessError as ex_err:
+            oradio_log.error("Error playing sound: %s", ex_err)
 
 # ------------------ TEST SECTION ------------------
 if __name__ == "__main__":
     print("\nStarting System Sound Player Standalone Test...\n")
-    
+
     # Initialize the volume_control, works stand alone
     volume_control = VolumeControl()
 

--- a/Python/remote_monitoring.py
+++ b/Python/remote_monitoring.py
@@ -171,7 +171,7 @@ class rms_service():
                                         })
 
             # Compile WARNING and ERROR message
-            elif msg_type ib (WARNING, ERROR):
+            elif msg_type in (WARNING, ERROR):
                 msg_data['message'] = json.dumps({'function': function, 'message': message})
                 # Send all log files in logging directory
                 self.send_files = glob.glob(ORADIO_LOG_DIR + "/*.log")

--- a/Python/test_backlighting.py
+++ b/Python/test_backlighting.py
@@ -92,7 +92,7 @@ def test_backlighting():
                        " 5-Test sensor mode\n"
                        "select: "
                        )
- 
+
     # User command loop
     while True:
 

--- a/Python/touch_buttons.py
+++ b/Python/touch_buttons.py
@@ -135,7 +135,7 @@ class TouchButtons:
             if button_name == "Play":
                 self.state_machine.transition("StateWebService")
             else:
-                oradio_log.error(f"LONG press detected on button: {button_name} (no action)")
+                oradio_log.error("LONG press detected on button: %s (no action)", button_name)
 
     def _extra_long_press_handler(self, button_name):
         """Handles extra-long press actions."""
@@ -143,7 +143,7 @@ class TouchButtons:
             if button_name == "Play":
                 self.state_machine.transition("StateWebServiceForceAP")
             else:
-                oradio_log.error(f"EXTRA LONG press detected on button: {button_name} (no action)")
+                oradio_log.error("EXTRA LONG press detected on button: %s (no action)", button_name)
 
     def cleanup(self):
         """Cleans up GPIO on exit."""

--- a/Python/usb_service.py
+++ b/Python/usb_service.py
@@ -51,12 +51,12 @@ class USBMonitor(PatternMatchingEventHandler):
 
     def on_created(self, event): # when file is created
         # do something, eg. call your function to process the image
-        oradio_log.info(f"{event.src_path} created")
+        oradio_log.info("%s created", event.src_path)
         self.service.usb_inserted()
 
     def on_deleted(self, event): # when file is deleted
         # do something, eg. call your function to process the image
-        oradio_log.info(f"{event.src_path} deleted")
+        oradio_log.info("%s deleted", event.src_path)
         self.service.usb_removed()
 
 class usb_service():
@@ -111,7 +111,7 @@ class usb_service():
             message["error"] = self.error
 
         # Put message in queue
-        oradio_log.debug(f"Send USB service message: {message}")
+        oradio_log.debug("Send USB service message: %s", message)
         self.msg_q.put(message)
 
     def get_state(self):
@@ -130,7 +130,7 @@ class usb_service():
 
             # Check if wifi credentials file exists in USB drive root
             if not os.path.isfile(USB_WIFI_FILE):
-                oradio_log.debug(f"'{USB_WIFI_FILE}' not found")
+                oradio_log.debug("'%s' not found", USB_WIFI_FILE)
                 return
 
             # Read and parse JSON file
@@ -139,7 +139,7 @@ class usb_service():
                     # Get JSON object as a dictionary
                     data = json.load(f)
                 except:
-                    oradio_log.error(f"Error parsing '{USB_WIFI_FILE}'")
+                    oradio_log.error("Error parsing '%s'", USB_WIFI_FILE)
                     self.error = MESSAGE_USB_ERROR_FILE
                     return
 
@@ -148,25 +148,25 @@ class usb_service():
                 ssid = data['SSID']
                 pswd = data['PASSWORD']
             else:
-                oradio_log.error(f"SSID and/or PASSWORD not found in '{USB_WIFI_FILE}'")
+                oradio_log.error("SSID and/or PASSWORD not found in '%s'", USB_WIFI_FILE)
                 self.error = MESSAGE_USB_ERROR_FILE
                 return
 
             # Test if ssid and pswd not empty
             if len(ssid) == 0 or len(pswd) == 0:
-                oradio_log.error(f"SSID={ssid} and/or PASSWORD={pswd} cannot be empty")
+                oradio_log.error("SSID=%s and/or PASSWORD=%s cannot be empty", ssid, pswd)
                 self.error = MESSAGE_USB_ERROR_FILE
                 return
 
             # Log wifi credentials found
-            oradio_log.info(f"USB wifi credentials found: ssid={ssid}, password={pswd}")
+            oradio_log.info("USB wifi credentials found: ssid=%s, password=%s", ssid, pswd)
 
             # Connect to the wifi network
             wifi_service(self.msg_q).wifi_connect(ssid, pswd)
 
         else:
             # USB is absent
-            oradio_log.info(f"USB state '{self.state}': Ignore '{USB_WIFI_FILE}'")
+            oradio_log.info("USB state '%s': Ignore '%s'", self.state, USB_WIFI_FILE)
 
     def usb_inserted(self):
         """
@@ -279,7 +279,7 @@ if __name__ == '__main__':
                     print("\nUSB service already running\n")
             case 2:
                 if monitor:
-                    print("\Simulate 'USB inserted' event...\n")
+                    print("\nSimulate 'USB inserted' event...\n")
                     monitor.usb_inserted()
                 else:
                     print("\nUSB service not running\n")
@@ -292,7 +292,6 @@ if __name__ == '__main__':
             case 4:
                 if monitor:
                     print(f"\nUSB state: {monitor.get_state()}\n")
-                    
                 else:
                     print("\nUSB service not running\n")
             case 5:

--- a/Python/volume_control.py
+++ b/Python/volume_control.py
@@ -21,8 +21,8 @@ Created on Januari 27, 2025
 """
 import time
 import threading
-import alsaaudio
 from queue import Queue
+import alsaaudio
 import smbus2
 
 

--- a/Python/volume_control.py
+++ b/Python/volume_control.py
@@ -20,10 +20,10 @@ Created on Januari 27, 2025
 @summary: Oradio Volume control
 """
 import time
-import alsaaudio
-import smbus2
 import threading
+import alsaaudio
 from queue import Queue
+import smbus2
 
 
 ##### oradio modules ####################
@@ -48,8 +48,8 @@ class VolumeControl:
         # Initialize ALSA Mixer
         try:
             self.mixer = alsaaudio.Mixer(ALSA_MIXER_DIGITAL)
-        except alsaaudio.ALSAAudioError as e:
-            oradio_log.error(f"Error initializing ALSA mixer: {e}")
+        except alsaaudio.ALSAAudioError as ex_err:
+            oradio_log.error("Error initializing ALSA mixer: %s", ex_err)
             raise
 
         # Initialize I2C Bus
@@ -65,8 +65,8 @@ class VolumeControl:
             data = self.bus.read_i2c_block_data(MCP3021_ADDRESS, 0, 2)
             adc_value = ((data[0] & 0x3F) << 6) | (data[1] >> 2)
             return adc_value
-        except OSError as e:
-            oradio_log.error(f"I2C read error: {e}")
+        except OSError as ex_err:
+            oradio_log.error("I2C read error: %s", ex_err)
             return None
 
     def scale_adc_to_volume(self, adc_value, adc_max=1023, vol_min=VOLUME_MINIMUM, vol_max=VOLUME_MAXIMUM):
@@ -77,10 +77,10 @@ class VolumeControl:
         """ Sets the volume using the ALSA mixer. """
         try:
             self.mixer.setvolume(volume_raw, units=alsaaudio.VOLUME_UNITS_RAW)
-            oradio_log.debug(f"Volume set to: {volume_raw}")
+            oradio_log.debug("Volume set to: %s", volume_raw)
 #            print(f"Volume set to: {volume_raw}")  # Print for testing
-        except alsaaudio.ALSAAudioError as e:
-            oradio_log.error(f"Error setting volume: {e}")
+        except alsaaudio.ALSAAudioError as ex_err:
+            oradio_log.error("Error setting volume: %s", ex_err)
 
     def send_message(self, message_type, state):
         """ Sends a message to the specified queue. """
@@ -88,9 +88,9 @@ class VolumeControl:
             try:
                 message = {"type": message_type, "state": state}
                 self.queue.put(message)
-                oradio_log.debug(f"Message sent to queue: {message}")
-            except Exception as e:
-                oradio_log.error(f"Error sending message to queue: {e}")
+                oradio_log.debug("Message sent to queue: %s", message)
+            except Exception as ex_err:
+                oradio_log.error("Error sending message to queue: %s", ex_err)
 
     def volume_adc(self):
         """ Monitors the ADC for changes and adjusts the volume accordingly. """
@@ -102,7 +102,7 @@ class VolumeControl:
         if initial_adc_value is not None:
             initial_volume = self.scale_adc_to_volume(initial_adc_value)
             self.set_volume(initial_volume)
-            oradio_log.debug(f"Initial volume set to: {initial_volume}")
+            oradio_log.debug("Initial volume set to: %s", initial_volume)
 
         while self.running:
             adc_value = self.read_adc()
@@ -116,7 +116,7 @@ class VolumeControl:
 
                     if polling_interval >= POLLING_MAX_INTERVAL:
                         self.send_message(MESSAGE_TYPE_VOLUME, MESSAGE_STATE_CHANGED)
-                    
+
                     polling_interval = POLLING_MIN_INTERVAL
                 else:
                     polling_interval = min(polling_interval + 0.01, POLLING_MAX_INTERVAL)

--- a/Python/wifi_service.py
+++ b/Python/wifi_service.py
@@ -24,8 +24,8 @@ Created on December 23, 2024
         https://pypi.org/project/nmcli/
         https://superfastpython.com/multiprocessing-in-python/
 """
-import nmcli
 from threading import Thread
+import nmcli
 
 ##### oradio modules ####################
 from oradio_utils import check_internet_connection, run_shell_script
@@ -66,7 +66,7 @@ class wifi_service():
         message["error"] = self.error
 
         # Put message in queue
-        oradio_log.debug(f"Send wifi message: {message}")
+        oradio_log.debug("Send wifi message: %s", message)
         self.msg_q.put(message)
 
     def wifi_connect(self, ssid, password):
@@ -85,7 +85,7 @@ class wifi_service():
 
         # Check if already connected to ssid
         if active == ssid:
-            oradio_log.debug(f"Connection '{ssid}' already active")
+            oradio_log.debug("Connection '%s' already active", ssid)
             # Inform controller of actual state and error
             self.send_message()
             # Return success, so caller can continue
@@ -95,11 +95,11 @@ class wifi_service():
         if active:
             # Stop the active connection
             try:
-                oradio_log.debug(f"Disconnect from: '{active}'")
+                oradio_log.debug("Disconnect from: '%s'", active)
                 # nmcli.connection.down(name: str, wait: int = None) -> None # Default timeout is 10 seconds
                 nmcli.connection.down(active)
             except Exception as ex_err:
-                oradio_log.error(f"Failed to disconnect from '{active}', error = {ex_err}")
+                oradio_log.error("Failed to disconnect from '%s', error = %s", active, ex_err)
                 # Inform controller of actual state and error
                 if ssid == ACCESS_POINT_SSID:
                     self.error = MESSAGE_WIFI_FAIL_AP_START
@@ -113,11 +113,11 @@ class wifi_service():
         if ssid in self.get_wifi_nm_connections() and ssid != self.saved_ssid:
             # Delete the ssid from NetworkManager
             try:
-                oradio_log.debug(f"Remove '{ssid}' from NetorkManager")
+                oradio_log.debug("Remove '%s' from NetorkManager", ssid)
                 # nmcli.connection.delete(name: str, wait: int = None) -> None # Default timeout is 10 seconds
                 nmcli.connection.delete(ssid)
             except Exception as ex_err:
-                oradio_log.error(f"Failed to remove '{ssid}' from NetworkManager, error = {ex_err}")
+                oradio_log.error("Failed to remove '%s' from NetworkManager, error = %s", ssid, ex_err)
                 # Inform controller of actual state and error
                 if ssid == ACCESS_POINT_SSID:
                     self.error = MESSAGE_WIFI_FAIL_AP_START
@@ -131,7 +131,7 @@ class wifi_service():
         if ssid == ACCESS_POINT_SSID:
             # Create access point
             try:
-                oradio_log.debug(f"Add '{ACCESS_POINT_SSID}' to NetworkManager")
+                oradio_log.debug("Add '%s' to NetworkManager", ACCESS_POINT_SSID)
                 options = {
                     "mode": "ap",
                     "ssid": ACCESS_POINT_SSID,
@@ -141,7 +141,7 @@ class wifi_service():
                 # nmcli.connection.add(conn_type: str, options: Optional[ConnectionOptions] = None, ifname: str = "*", name: str = None, autoconnect: Bool = None) -> None
                 nmcli.connection.add("wifi", options, "*", ACCESS_POINT_SSID, False)
             except Exception as ex_err:
-                oradio_log.error(f"Failed to add access point '{ACCESS_POINT_SSID}', error = {ex_err}")
+                oradio_log.error("Failed to add access point '%s', error = %s", ACCESS_POINT_SSID, ex_err)
                 # Inform controller of actual state and error
                 self.error = MESSAGE_WIFI_FAIL_AP_START
                 self.send_message()
@@ -152,7 +152,7 @@ class wifi_service():
             if ssid != self.saved_ssid:
                 # Add wifi network configuration
                 try:
-                    oradio_log.debug(f"Add '{ssid}' to NetworkManager")
+                    oradio_log.debug("Add '%s' to NetworkManager", ssid)
                     options = {
                         "ssid": ssid,
                         "wifi-sec.key-mgmt": "wpa-psk",
@@ -161,20 +161,20 @@ class wifi_service():
                     # nmcli.connection.add(conn_type: str, options: Optional[ConnectionOptions] = None, ifname: str = "*", name: str = None, autoconnect: Bool = None) -> None
                     nmcli.connection.add("wifi", options, "*", ssid, True)
                 except Exception as ex_err:
-                    oradio_log.error(f"Failed to configure wifi network '{ssid}', error = {ex_err}")
+                    oradio_log.error("Failed to configure wifi network '%s', error = %s", ssid, ex_err)
                     # Inform controller of actual state and error
                     self.error = MESSAGE_WIFI_FAIL_CONNECT
                     self.send_message()
                     # Return fail, so caller can try to recover
                     return False
             else:
-                oradio_log.debug(f"Network '{ssid}' already exists in NetworkManager")
+                oradio_log.debug("Network '%s' already exists in NetworkManager", ssid)
 
         # Connecting takes time, can fail: offload to a separate thread
         # ==> Don't use reference so that the python interpreter can garbage collect when thread is done
         Thread(target=self.wifi_connect_thread, args=(ssid, active,)).start()
 
-        oradio_log.info(f"Connecting to '{ssid}' started")
+        oradio_log.info("Connecting to '%s' started", ssid)
 
         # Return success, so caller can continue
         return True
@@ -189,11 +189,11 @@ class wifi_service():
 
         # Connect to new_ssid
         try:
-            oradio_log.debug(f"Activate '{new_ssid}'")
+            oradio_log.debug("Activate '%s'", new_ssid)
             # nmcli.connection.up(name: str, wait: int = None) -> None # Default timeout is 90 seconds
             nmcli.connection.up(new_ssid)
         except Exception as ex_err:
-            oradio_log.error(f"Failed to activate '{new_ssid}', error = {ex_err}")
+            oradio_log.error("Failed to activate '%s', error = %s", new_ssid, ex_err)
             if new_ssid == ACCESS_POINT_SSID:
                 self.error = MESSAGE_WIFI_FAIL_AP_START
             else:
@@ -202,39 +202,39 @@ class wifi_service():
             # Connect to the old_ssid
             if old_ssid:
                 try:
-                    oradio_log.debug(f"Failed to activate '{new_ssid}', activate '{old_ssid}'")
+                    oradio_log.debug("Failed to activate '%s', activate '%s'", new_ssid, old_ssid)
                     # nmcli.connection.up(name: str, wait: int = None) -> None # Default timeout is 90 seconds
                     nmcli.connection.up(old_ssid)
                 except Exception as ex_err:
-                    oradio_log.error(f"Failed to activate '{old_ssid}', error = {ex_err}")
+                    oradio_log.error("Failed to activate '%s', error = %s", old_ssid, ex_err)
                     if new_ssid == ACCESS_POINT_SSID:
                         self.error = MESSAGE_WIFI_FAIL_AP_START
                     else:
                         self.error = MESSAGE_WIFI_FAIL_CONNECT
                 else:
-                    oradio_log.info(f"Connect to '{old_ssid}' is active")
+                    oradio_log.info("Connect to '%s' is active", old_ssid)
 
             # Delete new_ssid from NetworkManager
             try:
-                oradio_log.debug(f"Failed to activate '{new_ssid}': remove from NetworkManager")
+                oradio_log.debug("Failed to activate '%s': remove from NetworkManager", new_ssid)
                 # nmcli.connection.delete(name: str, wait: int = None) -> None # Default timeout is 10 seconds
                 nmcli.connection.delete(new_ssid)
             except Exception as ex_err:
-                oradio_log.error(f"Failed to remove '{new_ssid}' from NetworkManager, error = {ex_err}")
+                oradio_log.error("Failed to remove '%s' from NetworkManager, error = %s", new_ssid, ex_err)
                 """ OMJ: NetworkManager now has an orphan. Do we need to do garbage collection? """
 
         # Connected to new_ssid: cleanup old_ssid
         else:
-            oradio_log.info(f"'{new_ssid}' is active")
+            oradio_log.info("'%s' is active", new_ssid)
 
             # Delete old_ssid from NetworkManager, if exists
             if old_ssid and old_ssid != self.saved_ssid:
                 try:
-                    oradio_log.debug(f"Remove '{old_ssid}' from NetworkManager")
+                    oradio_log.debug("Remove '%s' from NetworkManager", old_ssid)
                     # nmcli.connection.delete(name: str, wait: int = None) -> None # Default timeout is 10 seconds
                     nmcli.connection.delete(old_ssid)
                 except Exception as ex_err:
-                    oradio_log.error(f"Failed to remove '{old_ssid}' from NetworkManager, error = {ex_err}")
+                    oradio_log.error("Failed to remove '%s' from NetworkManager, error = %s", old_ssid, ex_err)
                     """ OMJ: NetworkManager now has an orphan. Do we need to do garbage collection? """
 
         # Inform controller of actual state and error
@@ -257,11 +257,11 @@ class wifi_service():
 
             # Stop the active connection
             try:
-                oradio_log.debug(f"Disconnect from: '{active}'")
+                oradio_log.debug("Disconnect from: '%s'", active)
                 # nmcli.connection.down(name: str, wait: int = None) -> None # Default timeout is 10 seconds
                 nmcli.connection.down(active)
             except Exception as ex_err:
-                oradio_log.error(f"Failed to disconnect from '{active}', error = {ex_err}")
+                oradio_log.error("Failed to disconnect from '%s', error = %s", active, ex_err)
                 # Inform controller of actual state and error
                 if active == ACCESS_POINT_SSID:
                     self.error = MESSAGE_WIFI_FAIL_AP_STOP
@@ -273,11 +273,11 @@ class wifi_service():
 
             # Delete the active network from NetworkManager
             try:
-                oradio_log.debug(f"Remove '{active}' from NetworkManager")
+                oradio_log.debug("Remove '%s' from NetworkManager", active)
                 # nmcli.connection.delete(name: str, wait: int = None) -> None # Default timeout is 10 seconds
                 nmcli.connection.delete(active)
             except Exception as ex_err:
-                oradio_log.error(f"Failed to remove '{active}' from NetworkManager, error = {ex_err}")
+                oradio_log.error("Failed to remove '%s' from NetworkManager, error = %s", active, ex_err)
                 # Inform controller of actual state and error
                 if active == ACCESS_POINT_SSID:
                     self.error = MESSAGE_WIFI_FAIL_AP_STOP
@@ -291,7 +291,7 @@ class wifi_service():
             self.send_message()
 
         # Return success, so caller can continue
-        oradio_log.info(f"Disconnected from: '{active}'")
+        oradio_log.info("Disconnected from: '%s'", active)
         return True
 
     def access_point_start(self, force_ap=False):
@@ -315,7 +315,7 @@ class wifi_service():
         cmd = "sudo bash -c 'echo \"address=/#/"+ACCESS_POINT_HOST+"\" > /etc/NetworkManager/dnsmasq-shared.d/redirect.conf'"
         result, error = run_shell_script(cmd)
         if not result:
-            oradio_log.error(f"Error during <{cmd}> to configure DNS redirection, error: {error}")
+            oradio_log.error("Error during <%s> to configure DNS redirection, error: %s", cmd, error)
             # Inform controller of actual state and error
             self.error = MESSAGE_WIFI_FAIL_AP_START
             self.send_message()
@@ -329,15 +329,15 @@ class wifi_service():
             if force_ap:
                 # Keep current network connection when an access point is started
                 self.saved_ssid = active
-                oradio_log.info(f"Save ssid '{self.saved_ssid}' for reconnect on stop")
+                oradio_log.info("Save ssid '%s' for reconnect on stop", self.saved_ssid)
             else:
-                oradio_log.debug(f"Keep active wifi network '{active}'")
+                oradio_log.debug("Keep active wifi network '%s'", active)
                 return True
 
-        oradio_log.debug(f"Activate access point '{ACCESS_POINT_SSID}'")
+        oradio_log.debug("Activate access point '%s'", ACCESS_POINT_SSID)
         # Setup and start acccess point
         if not self.wifi_connect(ACCESS_POINT_SSID, active):
-            oradio_log.error(f"Failed to connect '{ACCESS_POINT_SSID}'")
+            oradio_log.error("Failed to connect '%s'", ACCESS_POINT_SSID)
             # wifi_connect function informs controller
             # Return fail, so caller can try to recover
             return False
@@ -359,7 +359,7 @@ class wifi_service():
         cmd = "sudo rm -rf /etc/NetworkManager/dnsmasq-shared.d/redirect.conf"
         result, error = run_shell_script(cmd)
         if not result:
-            oradio_log.error(f"Error during <{cmd}> to remove DNS redirection, error: {error}")
+            oradio_log.error("Error during <%s> to remove DNS redirection, error: %s", cmd, error)
             # Inform controller of actual state and error
             self.error = MESSAGE_WIFI_FAIL_AP_STOP
             self.send_message()
@@ -371,19 +371,19 @@ class wifi_service():
 
             # Reconnect if any, ortherwise stop access point
             if self.saved_ssid:
-                oradio_log.info(f"Restore connection to '{self.saved_ssid}'")
+                oradio_log.info("Restore connection to '%s'", self.saved_ssid)
                 # Reconnect to saved wifi network
                 if not self.wifi_connect(self.saved_ssid, None):
-                    oradio_log.error(f"Failed to connect '{ACCESS_POINT_SSID}'")
+                    oradio_log.error("Failed to connect '%s'", ACCESS_POINT_SSID)
                     # wifi_connect function informs controller
                     # Return fail, so caller can try to recover
                     return False
 
             else:
                 # Disconnect and remove the access point without sending message
-                oradio_log.debug(f"Disconnect from '{ACCESS_POINT_SSID}'")
+                oradio_log.debug("Disconnect from '%s'", ACCESS_POINT_SSID)
                 if not self.wifi_disconnect():
-                    oradio_log.error(f"Failed to disconnect from '{ACCESS_POINT_SSID}'")
+                    oradio_log.error("Failed to disconnect from '%s'", ACCESS_POINT_SSID)
                     # wifi_connect function informs controller
                     # Return fail, so caller can try to recover
                     return False
@@ -404,13 +404,13 @@ class wifi_service():
 
         # Get available wifi networks
         try:
-            oradio_log.debug(f"Get list of networks broadcasting their ssid")
+            oradio_log.debug("Get list of networks broadcasting their ssid")
             # nmcli.device.wifi(ifname: str = None, rescan: bool = None) -> List[DeviceWifi]
             wifi_list = nmcli.device.wifi(None, None)
         except Exception as ex_err:
-            oradio_log.error(f"Failed to get wifi networks, error = {ex_err}")
+            oradio_log.error("Failed to get wifi networks, error = %s", ex_err)
         else:
-            oradio_log.debug(f"Remove '{ACCESS_POINT_SSID}' from the list")
+            oradio_log.debug("Remove '%s' from the list", ACCESS_POINT_SSID)
             for network in wifi_list:
                 # Add unique, ignore own Access Point
                 if (network.ssid != ACCESS_POINT_SSID) and (len(network.ssid) != 0) and (network.ssid not in networks):
@@ -432,7 +432,7 @@ class wifi_service():
             # nmcli.connection() -> List[Connection]
             connections = nmcli.connection()
         except Exception as ex_err:
-            oradio_log.error(f"Failed to get active connection, error = {ex_err}")
+            oradio_log.error("Failed to get active connection, error = %s", ex_err)
         else:
             # Inspect connections
             for connection in connections:
@@ -456,11 +456,11 @@ class wifi_service():
 
         # Get networks from NetworkManager
         try:
-            oradio_log.debug(f"Get connections from NetworkManager")
+            oradio_log.debug("Get connections from NetworkManager")
             # nmcli.connection() -> List[Connection]
             list = nmcli.connection()
         except Exception as ex_err:
-            oradio_log.error(f"Failed to get connections from NetworkManager, error = {ex_err}")
+            oradio_log.error("Failed to get connections from NetworkManager, error = %s", ex_err)
         else:
             # Inspect connections
             oradio_log.debug("Get wifi connections")
@@ -491,7 +491,8 @@ class wifi_service():
             else:
                 return STATE_WIFI_LOCAL_NETWORK
 
-''' Park until proven to be needed
+# Park until proven to be needed
+'''
     def wifi_nm_clean(self):
         """
         Remove networks in NetworkManager except the active connection


### PR DESCRIPTION
Voor de hand liggende fixes toegepast:
- overbodige spaties weg
- oradio_log.<...>(f"...{xxx}...") => oradio_log.<...>("...%s...", xxx)