### PR TITLE
Fix issue #281

### DIFF
--- a/Python/oradio_const.py
+++ b/Python/oradio_const.py
@@ -25,6 +25,13 @@ Created on December 23, 2024
 ################## SYSTEM #############################
 import os
 import sys
+
+# Colors
+RED    ='\033[0m\033[1;31m'
+YELLOW ='\033[0m\033[1;93m'
+GREEN  ='\033[0m\033[1;32m'
+NC     ='\033[0m'
+
 # Make Oradio file locations relative
 ORADIO_DIR      = sys.path[0]
 ORADIO_LOG_DIR  = os.path.abspath(ORADIO_DIR + '/../logging')
@@ -37,6 +44,7 @@ MESSAGE_NO_ERROR = "None"
 
 ################## WIFI UTILS #############################
 # Access point
+ACCESS_POINT_HOST = "108.156.60.1"  # wsj.com
 ACCESS_POINT_SSID = "OradioAP"
 # wifi states
 STATE_WIFI_IDLE         = "Wifi is not connected"
@@ -46,10 +54,11 @@ STATE_WIFI_ACCESS_POINT = "Wifi configured as access point"
 # wifi messages
 #OMJ: 'Type' is eigenlijk 'source'
 MESSAGE_WIFI_TYPE            = "Wifi message"
+MESSAGE_WIFI_FAIL_CONFIG     = "Failed to save credentials in NetworkManager"
+MESSAGE_WIFI_FAIL_START_AP   = "Failed to start access point"
 MESSAGE_WIFI_FAIL_CONNECT    = "Wifi failed to connect"
+MESSAGE_WIFI_FAIL_STOP_AP    = "Failed to stop access point"
 MESSAGE_WIFI_FAIL_DISCONNECT = "Wifi failed to disconnect"
-MESSAGE_WIFI_FAIL_AP_START   = "Failed to start access point"
-MESSAGE_WIFI_FAIL_AP_STOP    = "Failed to stop access point"
 
 ################## WEB SERVICE #############################
 # Web server address

--- a/Python/oradio_const.py
+++ b/Python/oradio_const.py
@@ -75,6 +75,7 @@ MESSAGE_WEB_SERVICE_PL2_CHANGED  = "PL2 playlist changed"
 MESSAGE_WEB_SERVICE_PL3_CHANGED  = "PL3 playlist changed"
 MESSAGE_WEB_SERVICE_PL_WEBRADIO  = "playlist is web radio"
 MESSAGE_WEB_SERVICE_PLAYING_SONG = "web service plays a song"
+MESSAGE_WEB_SERVICE_STOP         = "stop the web server"
 MESSAGE_WEB_SERVICE_FAIL_START   = "web service failed to start"
 MESSAGE_WEB_SERVICE_FAIL_STOP    = "web service failed to stop"
 

--- a/Python/oradio_control.py
+++ b/Python/oradio_control.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-function-docstring
 """
 
   ####   #####     ##    #####      #     ####
@@ -170,11 +171,11 @@ class StateMachine:
         # ————————————————————————————————
         play_states = {"StatePlay", "StatePreset1", "StatePreset2", "StatePreset3"}
         if self.state == requested_state and requested_state in play_states:
-            if not mpd.current_is_webradio():
+            if not mpd.current_is_webradio() and mpd.current_queue_filled():
                 threading.Thread(target=mpd.next).start()
                 sound_player.play("Next")
                 oradio_log.debug("Next song")
-            return
+                return
 
         # ————————————————————————————————
         # 2. SPOTIFY-CONNECT REDIRECT
@@ -204,9 +205,7 @@ class StateMachine:
             preset_key = requested_state.replace("State", "")
             if (
                 mpd.preset_is_webradio(preset_key)
-#OMJ: check de echte status , niet een pseude
-#                and self.network_mgr.state != "Internet"
-                and oradio_wifi_service.get_state() != STATE_WIFI_INTERNET
+                and self.network_mgr.state != "Internet"
             ):
                 oradio_log.info(
                     "Blocked transition to %s: preset is web radio but no Internet",
@@ -347,11 +346,10 @@ class StateMachine:
 
 class Networking:
     """
-    Combines web-service + wifi-service into one 4-state machine:
-      • APWebservice
-      • Internet
-      • ConnectedNoInternet
-      • Idle
+    Combines web-service + wifi-service into one 3-state machine:
+      • APWebservice: Oradio AP active
+      • Internet: Wifi connected to Internet
+      • Idle: No connection (to Internet)
     """
 
     def __init__(self, web_service, wifi_service):
@@ -362,54 +360,29 @@ class Networking:
         self.state = "Idle"
         self.task_lock = threading.Lock()
 
-#OMJ: No need to track AP anymore
-        # track whether we've entered APWebservice and not yet played WifiConnected
-        self.ap_tracker = False
-
     def transition(self):
         ws_state = self.web_service.get_state()
         wifi_state = self.wifi_service.get_state()
+     
+        #Networking StateMachine         StateWeb Service     State_Wifi
+        #APWebservice                   Active                - Not Relevant
+        #Internet                       - Not Relevant        Internet
+        #Idle                           - Not Relevant        Connected or Idle  
 
-        # Map (Wi-Fi, Web-Service) → Networking state:
-        #  • (Idle, Idle) or (Idle, Active)                 → Idle
-        #  • (Internet, Idle) or (Internet, Active)         → Internet
-        #  • (ConnectedNoInternet, Idle) or (ConnectedNoInternet, Active)
-        #                                                    → ConnectedNoInternet
-        #  • (AccessPoint, Active)                          → APWebservice
-        #  • (AccessPoint, Idle)                            → Idle
-
-#OMJ: New:
-        # Map Web-Service → Networking state:
-        #  • Idle                → Idle
-        #  • Active              → APWebservice
-
-        if (
-            ws_state == STATE_WEB_SERVICE_ACTIVE
-#OMJ: wifi_state is not relevant anymore
-#            and wifi_state == STATE_WIFI_ACCESS_POINT
-        ):
+        if (ws_state == STATE_WEB_SERVICE_ACTIVE):
             # AP mode + service running
             requested = "APWebservice"
 
-#OMJ: wifi_state is not relevant anymore
-#        elif wifi_state == STATE_WIFI_INTERNET:
-#            # normal Wi-Fi client with Internet
-#            requested = "Internet"
-
-#        elif wifi_state == STATE_WIFI_CONNECTED:
-#            # Wi-Fi client without Internet
-#            requested = "ConnectedNoInternet"
+        elif wifi_state == STATE_WIFI_INTERNET:
+            # normal Wi-Fi client with Internet
+            requested = "Internet"
 
         else:
-#OMJ: wifi_state is not relevant anymore
-            # covers both:
-            #   • wifi_state == STATE_WIFI_IDLE
-            #   • wifi_state == STATE_WIFI_ACCESS_POINT with WS idle
             requested = "Idle"
 
         #       oradio_log.info("Networking: %s → %s", self.state, requested)
 
-        # 2 no-op if same
+        # 2 no‐op if same
         if requested == self.state:
             oradio_log.info("Networking state is already %s", self.state)
             return
@@ -432,7 +405,7 @@ class Networking:
         with self.task_lock:
             # Handle APWebservice blinking on entry
             if new_state == "APWebservice":
-
+                
                 # 1) If we're currently in a preset state that is a WebRadio, stop it
                 play_presets = {"StatePreset1", "StatePreset2", "StatePreset3"}
                 curr = state_machine.state
@@ -455,7 +428,6 @@ class Networking:
 
                 leds.control_blinking_led("LEDPlay", 2)
                 sound_player.play("OradioAPstarted")
-                self.ap_tracker = True
                 oradio_log.info("Networking entered APWebservice state")
 
             #  Stop blinking only if we just left APWebservice
@@ -465,66 +437,17 @@ class Networking:
                 else:
                     leds.control_blinking_led("LEDPlay", 0)
                 sound_player.play("OradioAPstopped")
-
-#OMJ: No need to track AP anymore
-                self.ap_tracker = False
                 oradio_log.info("Networking left APWebservice state")
 
-#OMJ: Does this stay here? Is it a state? Why not handle at incoming messages (on_wifi_connected_to_internet)?
             if new_state == "Internet":
-                # play “WifiConnected” only when arriving (some states ago) from APWebservice
-                # only play “WifiConnected” when arriving from APWebservice
-                # and both the *previous* and *current* Oradio state are in play/webservice modes
-
-                #                 oradio_log.info(
-                #                 "Networking → Internet: prev_state=%s, current_state=%s",
-                #                 state_machine.prev_state,
-                #                 state_machine.state
-                #                 )
-                play_webservice_states = {
-                    "StatePlay",
-                    "StatePreset1",
-                    "StatePreset2",
-                    "StatePreset3",
-                    "StateWebService",
-                }
-                if self.ap_tracker and state_machine.state in play_webservice_states:
-                    # delay the tone so it doesn’t clash with any other sounds
-                    threading.Timer(
-                        4, sound_player.play, args=("WifiConnected",)
-                    ).start()
-                    self.ap_tracker = False
-
-                # Send system info to Remote Monitoring Service
                 remote_monitor.send_sys_info()
                 # Send heartbeat every hour to Remote Monitoring Service
                 remote_monitor.heartbeat_start()
                 oradio_log.info("Networking is in Internet state")
-            else:
+
+            if new_state == "Idle":
                 remote_monitor.heartbeat_stop()  # in all other cases, stop sending heartbeat
-
-#OMJ: Does this stay here? Is it a state? Why not handle at incoming messages (on_wifi_connected_no_internet)?
-#            if new_state == "ConnectedNoInternet":
-            if self.wifi_service.get_state() == STATE_WIFI_CONNECTED:
-                #  play “WifiNot  Connected” only when arriving from APWebservice
-                play_webservice_states = {
-                    "StatePlay",
-                    "StatePreset1",
-                    "StatePreset2",
-                    "StatePreset3",
-                    "StateWebService",
-                }
-                if state_machine.state in play_webservice_states:  # If in play states,
-                    if self.ap_tracker:
-                        sound_player.play("NoInternet")
-                        self.ap_tracker = False
-                oradio_log.info("Networking is in Connected No Internet state")
-
-            elif new_state == "Idle":
                 oradio_log.info("Networking is in Idle state")
-            else:
-                # this covers new_state == "APWebservice" again, or unexpected
-                pass
 
 
 # ---------------USB_Media state machine-----------------------
@@ -640,61 +563,23 @@ def on_usb_present():
 
 # -------------------WIFI--------------------------
 
-# All state  wifi and web services changes are handled by the Message handler and Networking_mgr
-
+# Messages when after the closure of the Oradio AP Webservice the Wifi connection is/not made
 
 def on_wifi_connected_to_internet():
     oradio_log.debug("Wifi is connected to internet acknowledged")
-#OMJ: to test, needs to be put back in statemachine
     play_webservice_states = {
         "StatePlay",
         "StatePreset1",
         "StatePreset2",
         "StatePreset3",
+        "StateWebService",
     }
     if state_machine.state in play_webservice_states:  # If in play states,
-        # delay the tone so it doesn’t clash with any other sounds
-        threading.Timer(4, sound_player.play, args=("WifiConnected",)).start()
-        # Send system info to Remote Monitoring Service
-        remote_monitor.send_sys_info()
-        # Send heartbeat every hour to Remote Monitoring Service
-        remote_monitor.heartbeat_start()
+        threading.Timer(
+            4, sound_player.play, args=("WifiConnected",)
+        ).start()
 
-def on_wifi_connected_no_internet():
-    oradio_log.debug("Wifi is connected NO internet acknowledged")
-#OMJ: to test, needs to be put back in statemachine
-    play_webservice_states = {
-        "StatePlay",
-        "StatePreset1",
-        "StatePreset2",
-        "StatePreset3",
-    }
-    if state_machine.state in play_webservice_states:  # If in play states,
-        # delay the tone so it doesn’t clash with any other sounds
-        threading.Timer(4, sound_player.play, args=("NoInternet",)).start()
-        # Stop heartbeat to Remote Monitoring Service
-        remote_monitor.heartbeat_stop()
-
-def on_wifi_not_connected():
-    oradio_log.debug("Wifi is NOT connected acknowledged")
-#OMJ: to test, needs to be put back in statemachine
-    play_webservice_states = {
-        "StatePlay",
-        "StatePreset1",
-        "StatePreset2",
-        "StatePreset3",
-    }
-    if state_machine.state in play_webservice_states:  # If in play states,
-        # delay the tone so it doesn’t clash with any other sounds
-        threading.Timer(4, sound_player.play, args=("WifiNotConnected",)).start()
-        # Stop heartbeat to Remote Monitoring Service
-        remote_monitor.heartbeat_stop()
-
-def on_wifi_access_point():
-    oradio_log.debug("Configured as access point acknowledged")
-#OMJ: This should not happen anymore
-
-def on_wifi_error():
+def on_wifi_fail_connect():
     play_webservice_states = {
         "StatePlay",
         "StatePreset1",
@@ -705,6 +590,19 @@ def on_wifi_error():
     if state_machine.state in play_webservice_states:  # If in play states,
         sound_player.play("WifiNotConnected")  #
     oradio_log.debug("Wifi Error acknowledged")
+
+#placeholders
+def on_wifi_connected_no_internet():
+    oradio_log.debug("Wifi is connected NO internet acknowledged")
+
+def on_wifi_not_connected():
+    oradio_log.debug("Wifi is NOT connected acknowledged")
+
+def on_wifi_access_point():
+    oradio_log.debug("Configured as access point acknowledged")
+
+
+
 
 
 # -------------------WEB---------------------------
@@ -845,7 +743,7 @@ HANDLERS = {
         STATE_WIFI_INTERNET: on_wifi_connected_to_internet,
         STATE_WIFI_CONNECTED: on_wifi_connected_no_internet,
         STATE_WIFI_ACCESS_POINT: on_wifi_access_point,
-        MESSAGE_WIFI_FAIL_CONNECT: on_wifi_error,
+        MESSAGE_WIFI_FAIL_CONNECT: on_wifi_fail_connect,
     },
     MESSAGE_WEB_SERVICE_TYPE: {
         STATE_WEB_SERVICE_IDLE: on_webservice_idle,

--- a/Python/touch_buttons.py
+++ b/Python/touch_buttons.py
@@ -29,7 +29,7 @@ from led_control import LEDControl  # Import LED control module
 
 ##### LOCAL constants ####################
 # Debounce time in milliseconds to ignore rapid repeat triggers
-BUTTON_DEBOUNCE_TIME = 300
+BUTTON_DEBOUNCE_TIME = 500
 
 # Define button GPIO mappings globally
 BUTTONS = {
@@ -43,8 +43,10 @@ BUTTONS = {
 # Press durations
 LONG_PRESS_DURATION = 6         # Seconds for long press
 
+
 class TouchButtons:
-    """Handles GPIO-based touch buttons with debounce, long, and extra-long press detection."""
+    """Handles GPIO-based touch buttons with debounce, immediate short-press actions,
+    and continuous-hold long-press detection optimized for speed."""
 
     def __init__(self, state_machine=None):
         """
@@ -55,96 +57,130 @@ class TouchButtons:
         self.sound_player = PlaySystemSound()
         self.led_control = LEDControl()
 
-        # Track press and debounce
-        self.button_press_times = {}      # For long press timing
-        self.last_trigger_times = {}      # For debounce timing (seconds since epoch)
+        # Press tracking
+        self.button_press_times = {}      # For press timestamps
+        self.last_trigger_times = {}      # For software debounce (seconds since epoch)
+        self.long_press_timers = {}       # button_name -> threading.Timer
+        self.long_press_fired = set()     # button_names where long press already handled
+
+        # Public overridable long-press handler; test code may assign to this
+        self.long_press_handler = self._default_long_press_handler
+
         self.gpio_to_button = {pin: name for name, pin in BUTTONS.items()}
 
         self._setup_gpio()
 
     def _setup_gpio(self):
-        """Configures GPIO pins and sets up event detection with minimal bouncetime."""
+        """Configures GPIO pins and sets up edge detection (both edges) with a single callback."""
         GPIO.setmode(GPIO.BCM)
         for pin in BUTTONS.values():
             GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
             GPIO.add_event_detect(
                 pin,
-                GPIO.FALLING,
-                callback=self._button_callback,
+                GPIO.BOTH,
+                callback=self._edge_callback,
                 bouncetime=10
             )
 
-    def _button_callback(self, channel):
-        """Handles initial button press events with debounce."""
+    def _edge_callback(self, channel):
+        """Unified handler for both press (falling) and release (rising) edges."""
         button_name = self.gpio_to_button.get(channel)
         if not button_name:
             return
 
-        # Debounce: ignore if within BUTTON_DEBOUNCE_TIME
+        level = GPIO.input(channel)
+        if level == GPIO.LOW:
+            self._handle_press(channel, button_name)
+        else:
+            self._handle_release(channel, button_name)
+
+    def _handle_press(self, channel, button_name):
+        """Handle falling-edge: immediate short-press action plus start long-press timer."""
         now = time.monotonic()
         last = self.last_trigger_times.get(button_name, 0)
         if (now - last) * 1000 < BUTTON_DEBOUNCE_TIME:
-            return
+            return  # software debounce
         self.last_trigger_times[button_name] = now
+        self.button_press_times[button_name] = now
 
-        # Play click sound immediately
+        prev_timer = self.long_press_timers.pop(button_name, None)
+        if prev_timer:
+            prev_timer.cancel()
+        self.long_press_fired.discard(button_name)
+
+        timer = threading.Timer(
+            LONG_PRESS_DURATION,
+            self._long_press_timeout,
+            args=(channel, button_name)
+        )
+        timer.daemon = True
+        self.long_press_timers[button_name] = timer
+        timer.start()
+
+        # Immediate feedback (short press semantics)
         self.sound_player.play("Click")
-
-        # State transition
         new_state = f"State{button_name}"
         if self.state_machine:
             self.state_machine.transition(new_state)
 
-        # Record for long press detection and spawn detector thread
-        self.button_press_times[button_name] = now
+    def _handle_release(self, _channel, button_name):
+        """Handle rising-edge: cancel pending long-press detection if any."""
+        timer = self.long_press_timers.pop(button_name, None)
+        if timer:
+            timer.cancel()
+
+        if button_name in self.long_press_fired:
+            self.long_press_fired.discard(button_name)
+
+        # Short press already handled on falling edge; nothing else needed.
+
+    def _long_press_timeout(self, channel, button_name):
+        """Fires if the button has been held continuously for LONG_PRESS_DURATION."""
+        if GPIO.input(channel) != GPIO.LOW:
+            return
+
+        self.long_press_fired.add(button_name)
+        self.long_press_timers.pop(button_name, None)
+
+        # Run the (possibly overridden) handler asynchronously
         threading.Thread(
-            target=self._detect_long_press,
-            args=(channel, button_name),
+            target=self._run_long_press_handler,
+            args=(button_name,),
             daemon=True
         ).start()
+
+    def _run_long_press_handler(self, button_name):
+        """Invoker for the public long_press_handler attribute."""
+        try:
+            self.long_press_handler(button_name)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Defensive: ensure user-supplied handler failures do not crash the timer path
+            oradio_log.exception("Exception in long press handler for %s", button_name)
+
+    def _default_long_press_handler(self, button_name):
+        """Default long-press behavior if not overridden."""
+        if self.state_machine:
+            if button_name == "Play":
+                self.state_machine.start_webservice()
+            else:
+                oradio_log.info(
+                    "LONG press detected on button: %s (no action)", button_name
+                )
 
     def _blink_led(self):
         """Blinks all LEDs off after a short delay."""
         time.sleep(0.05)
         self.led_control.turn_off_all_leds()
 
-    def _detect_long_press(self, channel, button_name):
-        """Detects long presses without drifting under load."""
-        # Calculate how much time has already elapsed since the button went down
-        start = self.button_press_times.get(button_name, time.monotonic())
-        elapsed = time.monotonic() - start
-
-        # Sleep only the remaining time (if any)
-        remaining = LONG_PRESS_DURATION - elapsed
-        if remaining > 0:
-            time.sleep(remaining)
-
-        # Final guard: fire only if the button is still held
-        if GPIO.input(channel) == GPIO.LOW:
-            threading.Thread(
-                target=self._long_press_handler,
-                args=(button_name,),
-                daemon=True
-            ).start()
-
-    def _long_press_handler(self, button_name):
-        """Handles long press actions."""
-        if self.state_machine:
-            if button_name == "Play":
-                self.state_machine.start_webservice()
-            else:
-                oradio_log.error(
-                    "LONG press detected on button: %s (no action)", button_name
-                )
-
     def cleanup(self):
-        """Cleans up GPIO on exit."""
+        """Cleans up GPIO on exit. Also cancels any pending timers."""
+        for timer in list(self.long_press_timers.values()):
+            timer.cancel()
         GPIO.cleanup()
+
 
 # ------------------ Standalone Test Mode ------------------
 if __name__ == "__main__":
-    import time
-
     LONG = LONG_PRESS_DURATION
 
     print("\nStarting Touch Buttons Test Mode…\n")
@@ -152,12 +188,13 @@ if __name__ == "__main__":
     print(f" • Long press  (>= {LONG}s): double LED blink + console msg")
     print("Press Ctrl+C to exit.\n")
 
-    # Instantiate without test_mode
+    # Instantiate without a real state machine
     tb = TouchButtons(state_machine=None)
 
-    # Monkey-patch a fake state machine for short presses
     class DummyStateMachine:
+        """Simple stub state machine for test mode to show short presses."""
         def transition(self, new_state):
+            """Handle a short-press transition by blinking the corresponding LED."""
             btn = new_state.replace("State", "")
             print(f"[TEST] Short press on {btn!r}")
             led = f"LED{btn}"
@@ -167,8 +204,8 @@ if __name__ == "__main__":
 
     tb.state_machine = DummyStateMachine()
 
-    # Monkey-patch the long-press handler
     def test_long_press(button_name):
+        """Test-mode replacement for long-press handling."""
         print(f"[TEST] Long press on {button_name!r}")
         led = f"LED{button_name}"
         for _ in range(2):
@@ -177,7 +214,7 @@ if __name__ == "__main__":
             tb.led_control.turn_off_all_leds()
             time.sleep(0.1)
 
-    tb._long_press_handler = test_long_press
+    tb.long_press_handler = test_long_press
 
     try:
         while True:
@@ -186,3 +223,4 @@ if __name__ == "__main__":
         print("\nExiting test mode…")
     finally:
         tb.cleanup()
+        

--- a/Python/wifi_service.py
+++ b/Python/wifi_service.py
@@ -42,8 +42,6 @@ from oradio_const import (
     MESSAGE_WIFI_FAIL_CONFIG,
     MESSAGE_WIFI_FAIL_START_AP,
     MESSAGE_WIFI_FAIL_CONNECT,
-    MESSAGE_WIFI_FAIL_STOP_AP,
-    MESSAGE_WIFI_FAIL_DISCONNECT,
     MESSAGE_NO_ERROR
 )
 
@@ -471,9 +469,9 @@ if __name__ == '__main__':
                 print(f"\nNetworkManager wifi connections: {_networkmanager_list()}\n") # pylint: disable=protected-access
             case 2:
                 name = input("Enter SSID of the network to add: ")
-                password = input("Enter password for the network to add (empty for open network): ")
+                pswrd = input("Enter password for the network to add (empty for open network): ")
                 if name:
-                    if _networkmanager_add(name, password): # pylint: disable=protected-access
+                    if _networkmanager_add(name, pswrd): # pylint: disable=protected-access
                         print(f"\n{GREEN}'{name}' added to NetworkManager{NC}\n")
                     else:
                         print(f"\n{RED}Failed to add '{name}' to NetworkManager{NC}\n")
@@ -494,16 +492,16 @@ if __name__ == '__main__':
             case 5:
                 print(f"\nActive wifi networks: {get_wifi_networks()}\n")
             case 6:
-                state = wifi.get_state()
-                if state == STATE_WIFI_IDLE:
-                    print(f"\nWiFi state: '{state}'\n")
+                wifi_state = wifi.get_state() # pylint: disable=invalid-name
+                if wifi_state == STATE_WIFI_IDLE:
+                    print(f"\nWiFi state: '{wifi_state}'\n")
                 else:
-                    print(f"\nWiFi state: '{state}'. Connected with: '{get_wifi_connection()}'\n")
+                    print(f"\nWiFi state: '{wifi_state}'. Connected with: '{get_wifi_connection()}'\n")
             case 7:
                 name = input("Enter SSID of the network to add: ")
-                password = input("Enter password for the network to add (empty for open network): ")
+                pswrd = input("Enter password for the network to add (empty for open network): ")
                 if name:
-                    wifi.wifi_connect(name, password)
+                    wifi.wifi_connect(name, pswrd)
                     print(f"\nConnecting with '{name}'. Check messages for result\n")
                 else:
                     print(f"\n{YELLOW}No network given{NC}\n")
@@ -514,7 +512,7 @@ if __name__ == '__main__':
             case 9:
                 print("\nWiFi disconnected: check messages for result\n")
                 wifi.wifi_disconnect()
-                print(f"\nDisconnecting. Check messages for result\n")
+                print("\nDisconnecting. Check messages for result\n")
             case _:
                 print(f"\n{YELLOW}Please input a valid number{NC}\n")
 

--- a/Python/wifi_service.py
+++ b/Python/wifi_service.py
@@ -14,12 +14,10 @@ Created on December 23, 2024
 @copyright:     Copyright 2024, Oradio Stichting
 @license:       GNU General Public License (GPL)
 @organization:  Oradio Stichting
-@version:       3
+@version:       4
 @email:         oradioinfo@stichtingoradio.nl
 @status:        Development
 @summary: Class for wifi connectivity services
-    :Note
-    :Install
     :Documentation
         https://pypi.org/project/nmcli/
         https://superfastpython.com/multiprocessing-in-python/
@@ -33,21 +31,23 @@ from oradio_logging import oradio_log
 
 ##### GLOBAL constants ####################
 from oradio_const import (
+    RED, GREEN, YELLOW, NC,
+    ACCESS_POINT_HOST,
     ACCESS_POINT_SSID,
     MESSAGE_WIFI_TYPE,
     STATE_WIFI_IDLE,
     STATE_WIFI_INTERNET,
     STATE_WIFI_CONNECTED,
     STATE_WIFI_ACCESS_POINT,
+    MESSAGE_WIFI_FAIL_CONFIG,
+    MESSAGE_WIFI_FAIL_START_AP,
     MESSAGE_WIFI_FAIL_CONNECT,
+    MESSAGE_WIFI_FAIL_STOP_AP,
     MESSAGE_WIFI_FAIL_DISCONNECT,
-    MESSAGE_WIFI_FAIL_AP_START,
-    MESSAGE_WIFI_FAIL_AP_STOP,
     MESSAGE_NO_ERROR
 )
 
 ##### LOCAL constants ####################
-AP_HOST = "108.156.60.1"  # wsj.com
 
 class WifiService():
     """
@@ -57,20 +57,27 @@ class WifiService():
     """
     def __init__(self, queue):
         """
-        Initialize wifi state and error
-        Report to parent process
+        Initialize wifi state
+        Setup access point in NetworkManager
+        Report state and error to parent process
         """
         # Initialize
         self.msg_q = queue
-        self.saved_network = None
+        self.saved = None
+
+        # Add access point credentials to NetworkManager
+        if not _networkmanager_add(ACCESS_POINT_SSID):
+            error = MESSAGE_WIFI_FAIL_CONFIG
+        else:
+            error = MESSAGE_NO_ERROR
 
         # Send initial state and error message
-        self._send_message(MESSAGE_NO_ERROR)
+        self._send_message(error)
 
     def _send_message(self, error):
         """
         Send wifi service message
-        :param error: Error message or code to include in the message
+        :param error: Error message
         """
         # Create message
         message = {
@@ -80,7 +87,10 @@ class WifiService():
         }
         # Put message in queue
         oradio_log.debug("Send wifi service message: %s", message)
-        self.msg_q.put(message)
+        if self.msg_q:
+            self.msg_q.put(message)
+        else:
+            oradio_log.error("No queue proviced to send wifi service message")
 
     def get_state(self):
         """
@@ -102,12 +112,17 @@ class WifiService():
         # Connection to wifi network WITHOUT internet access
         return STATE_WIFI_CONNECTED
 
+    def get_saved_wifi(self):
+        """
+        Public function
+        Return the ssid of the last wifi connection
+        """
+        return self.saved
+
     def wifi_connect(self, ssid, pswd): # pylint: disable=too-many-branches
         """
         Public function
-        Done if already connected
-        Create unique wifi network in NetworkManager
-        Manage DNS redirection and reconnection to previous network for access point
+        Create/modify wifi network in NetworkManager
         Start thread to connect to the wifi network
         :param ssid: Identifier of wifi network to create
         :param pswd: Password of wifi network to create
@@ -115,87 +130,17 @@ class WifiService():
         # Get active wifi connection, if any
         active = get_wifi_connection()
 
-        # Check if already connected to ssid
-        if active == ssid:
-            oradio_log.debug("Connection '%s' already active", ssid)
+        # Store network connection, but not if access point
+        if active != ACCESS_POINT_SSID:
+            oradio_log.info("Remember connection '%s'", active)
+            self.saved = active
+
+        # Add/modify NetworkManager settings
+        if not _networkmanager_add(ssid, pswd):
             # Inform controller of actual state and error
-            self._send_message(MESSAGE_NO_ERROR)
-            # Return success, so caller can continue
+            self._send_message(MESSAGE_WIFI_FAIL_CONFIG)
+            # Error, no point continuing
             return
-
-        # Configure if starting access point
-        if ssid == ACCESS_POINT_SSID:
-
-            # Keep current network connection when an access point is started
-            if active:
-                oradio_log.info("Save '%s' for reconnect", active)
-                self.saved_network = {"ssid": active, "pswd": _get_wifi_password(active)}
-
-            # Configure DNS redirection
-            oradio_log.debug("Redirect DNS")
-            cmd = "sudo bash -c 'echo \"address=/#/"+AP_HOST+"\" > /etc/NetworkManager/dnsmasq-shared.d/redirect.conf'"
-            result, error = run_shell_script(cmd)
-            if not result:
-                oradio_log.error("Error during <%s> to configure DNS redirection, error: %s", cmd, error)
-                # Send message with current state and error message
-                self._send_message(MESSAGE_WIFI_FAIL_AP_START)
-
-                # Reconnect to saved network (wifi_connect logs and sends message)
-                if self.saved_network:
-                    oradio_log.info("Reconnecting to saved_network: '%s'", self.saved_network.get("ssid"))
-                    self.wifi_connect(self.saved_network.get("ssid"), self.saved_network.get("pswd"))
-                    # Clear saved network
-                    self.saved_network = None
-
-                # Return fail, so caller can try to recover
-                return
-
-        # Removing before adding == replacing the network settings, just in case the password has changed
-        # Disconnect and remove the current connection, not trying to reconnect (wifi_disconnect logs and sends message)
-        self.wifi_disconnect(False)
-
-        # Add network settings to NetworkManager
-        if ssid == ACCESS_POINT_SSID:
-            # Add access point credentials
-            oradio_log.debug("Add '%s' to NetworkManager", ACCESS_POINT_SSID)
-            options = {
-                "mode": "ap",
-                "ssid": ACCESS_POINT_SSID,
-                "ipv4.method": "shared",
-                "ipv4.address": AP_HOST+"/24"
-            }
-            if not _networkmanager_add(ssid, options, False):
-                # Inform controller of actual state and error
-                self._send_message(MESSAGE_WIFI_FAIL_AP_START)
-
-                # Reconnect to saved network (wifi_connect logs and sends message)
-                if self.saved_network:
-                    oradio_log.info("Reconnecting to saved_network: '%s'", self.saved_network.get("ssid"))
-                    self.wifi_connect(self.saved_network.get("ssid"), self.saved_network.get("pswd"))
-                    # Clear saved network
-                    self.saved_network = None
-
-                # Return fail, so caller can try to recover
-                return
-        else:
-            # Add network credentials
-            if pswd:
-                oradio_log.debug("Add '%s' and password to NetworkManager", ssid)
-                options = {
-                    "ssid": ssid,
-                    "wifi-sec.key-mgmt": "wpa-psk",
-                    "wifi-sec.psk": pswd
-                }
-            else:
-                oradio_log.debug("Add '%s' without password to NetworkManager", ssid)
-                options = {
-                    "ssid": ssid
-                }
-            if not _networkmanager_add(ssid, options, True):
-                # Inform controller of actual state and error
-                self._send_message(MESSAGE_WIFI_FAIL_CONNECT)
-                # Return fail, so caller can try to recover
-                return
 
         # Connecting takes time, can fail: offload to a separate thread
         # ==> Don't use reference so that the python interpreter can garbage collect when thread is done
@@ -208,85 +153,44 @@ class WifiService():
         Private function
         Activate the network
         :param network: wifi network ssid as configured in NetworkManager
-        On error fall back to previous network
-        Send message with result
+        On error determine error message
+        Send message with actual state and error info
         """
+        # Initialize: assume no error
+        err_msg = MESSAGE_NO_ERROR
+
         # Connect to network
         if not _wifi_up(network):
-            oradio_log.error("Failed to connect to '%s'", network)
-
-            # Remove failing network from NetworkManager (_networkmanager_remove logs)
-            _networkmanager_remove(network)
-
-            # Inform controller of actual state and error
+            oradio_log.error("Failed to connect with '%s'", network)
+            # Inform control of error
             if network == ACCESS_POINT_SSID:
-                # Send message with current state and error message
-                self._send_message(MESSAGE_WIFI_FAIL_AP_START)
-
-                # Reconnect to saved network (wifi_connect logs and sends message)
-                if self.saved_network:
-                    oradio_log.info("Reconnecting to saved_network: '%s'", self.saved_network.get("ssid"))
-                    self.wifi_connect(self.saved_network.get("ssid"), self.saved_network.get("pswd"))
-                    # Clear saved network
-                    self.saved_network = None
+                err_msg = MESSAGE_WIFI_FAIL_START_AP
             else:
-                self._send_message(MESSAGE_WIFI_FAIL_CONNECT)
+                err_msg = MESSAGE_WIFI_FAIL_CONNECT
         else:
-            oradio_log.info("'%s' is active", network)
+            oradio_log.info("Connected with '%s'", network)
 
-            # Inform controller of actual state and error
-            self._send_message(MESSAGE_NO_ERROR)
+        # Inform controller of actual state and error info
+        self._send_message(err_msg)
 
-    def wifi_disconnect(self, reconnect=True):
+    def wifi_disconnect(self):
         """
         Public function
         Disconnect if connected
-        Remove connection from NetworkManager
-        :param reconnect: If True reconnect to saved network
-        Send message with actual state and error info, if any
+        No messages required
         """
         # Get active wifi connection, if any
         active = get_wifi_connection()
 
-        # If connected then disconnect and remove from NetworkManager
+        # If connected then disconnect
         if active:
-
-            # Stop the active connection and remove from NetworkManager
-            if not _wifi_down(active) or not _networkmanager_remove(active):
-                # Inform controller of actual state and error
-                self._send_message(MESSAGE_WIFI_FAIL_DISCONNECT)
-                # Return fail, so caller can try to recover
-                return
-
-            # Cleanup if stopping access point
-            if active == ACCESS_POINT_SSID:
-                # Remove address redirection
-                oradio_log.debug("Remove DNS redirection")
-                cmd = "sudo rm -rf /etc/NetworkManager/dnsmasq-shared.d/redirect.conf"
-                result, error = run_shell_script(cmd)
-                if not result:
-                    oradio_log.error("Error during <%s> to remove DNS redirection, error: %s", cmd, error)
-                    # Send message with current state and error message
-                    self._send_message(MESSAGE_WIFI_FAIL_AP_STOP)
-                    # Return fail, so caller can try to recover
-                    return
-
-                # Reconnect to saved network (wifi_connect logs and sends message)
-                if reconnect and self.saved_network:
-                    oradio_log.info("Reconnecting to saved_network: '%s'", self.saved_network.get("ssid"))
-                    self.wifi_connect(self.saved_network.get("ssid"), self.saved_network.get("pswd"))
-
-                    # Clear saved network
-                    self.saved_network = None
-                else:
-                    oradio_log.debug("Not reconnecting")
-
-            oradio_log.info("Disconnected from: '%s'", active)
+            # Stop the active connection
+            if not _wifi_down(active):
+                oradio_log.error("Failed to disconnect from '%s'", active)
+            else:
+                oradio_log.info("Disconnected from: '%s'", active)
         else:
             oradio_log.debug("Already disconnected")
-
-        # Inform controller of actual state, no error
-        self._send_message(MESSAGE_NO_ERROR)
 
 def get_wifi_networks():
     """
@@ -327,7 +231,6 @@ def get_wifi_connection():
     network = None
 
     try:
-        oradio_log.debug("Get active connection")
         # Get all network connections
         # nmcli.connection() -> List[Connection]
         connections = nmcli.connection()
@@ -340,7 +243,7 @@ def get_wifi_connection():
             if connection.conn_type == "wifi" and connection.device != "--":
                 # Get connection details, inspect GENERAL.STATE
                 details = nmcli.connection.show(connection.name)
-                if details["GENERAL.STATE"] == "activated":
+                if details.get("GENERAL.STATE") == "activated":
                     # Connection is wifi, has device and is activated
                     network = connection.name
 
@@ -415,7 +318,6 @@ def _networkmanager_list():
         oradio_log.error("Failed to get connections from NetworkManager, error = %s", ex_err)
     else:
         # Inspect connections
-        oradio_log.debug("Get wifi connections")
         for connection in result:
             # Only wifi connections
             if connection.conn_type == "wifi":
@@ -423,25 +325,70 @@ def _networkmanager_list():
 
     return connections
 
-def _networkmanager_add(network, config, autoconnect):
+def _networkmanager_add(network, password=None):
     """
     Private function
-    Add given network to NetworkManager
+    if network is access point then setup AP in NetworkManager
+    If unknown, add network to NetworkManager
+    If exists, modify network in NetworkManager
     :param network: wifi network ssid to be configured in NetworkManager
-    :param config: wifi network configuration to be configured in NetworkManager
-    :param autoconnect: Automatically reconnect if connection gets lost
+    :param password: wifi network password to be configured in NetworkManager
     nmcli does not raise specific exception
     """
-    try:
-        oradio_log.debug("Add '%s' to NetworkManager", network)
-        # nmcli.connection.add(conn_type: str, options: Optional[ConnectionOptions] = None, ifname: str = "*", name: str = None, autoconnect: Bool = None) -> None
-        nmcli.connection.add("wifi", config, "*", network, autoconnect)
-    except Exception as ex_err:       # pylint: disable=broad-exception-caught
-        oradio_log.error("Failed to add '%s' to NetworkManager, error = %s", network, ex_err)
-        return False
+    # Add access point to NetworkManager if not exist
+    if network == ACCESS_POINT_SSID:
+        if ACCESS_POINT_SSID in _networkmanager_list():
+            oradio_log.debug("'%s' already in NetworkManager", ACCESS_POINT_SSID)
+            return True
+
+        oradio_log.debug("Add '%s' to NetworkManager", ACCESS_POINT_SSID)
+        options = {
+            "mode": "ap",
+            "ssid": ACCESS_POINT_SSID,
+            "ipv4.method": "shared",
+            "ipv4.address": ACCESS_POINT_HOST+"/24"
+        }
+        try:
+            # nmcli.connection.add(conn_type: str, options: Optional[ConnectionOptions] = None, ifname: str = "*", name: str = None, autoconnect: Bool = None) -> None
+            nmcli.connection.add("wifi", options, "*", ACCESS_POINT_SSID, False)
+        except Exception as ex_err: # pylint: disable=broad-exception-caught
+            oradio_log.error("Failed to add '%s' to NetworkManager, error = %s", ACCESS_POINT_SSID, ex_err)
+            return False
+
+    # Add network to NetworkManager if not exist, modify if exists
+    else:
+        # Setup connection options
+        options = {"ssid": network}
+        if password:
+            oradio_log.debug("Use '%s' with password", network)
+            options.update({
+                "wifi-sec.key-mgmt": "wpa-psk",
+                "wifi-sec.psk": password
+            })
+        else:
+            oradio_log.debug("Use '%s' without password", network)
+
+        if network in _networkmanager_list():
+            oradio_log.debug("Modify '%s' in NetworkManager", network)
+            try:
+                # nmcli.connection.modify(name: str, options: ConnectionOptions) -> None
+                nmcli.connection.modify(network, options)
+            except Exception as ex_err: # pylint: disable=broad-exception-caught
+                oradio_log.error("Failed to modify '%s' in NetworkManager, error = %s", network, ex_err)
+                return False
+        else:
+            oradio_log.debug("Add '%s' to NetworkManager", network)
+            try:
+                # nmcli.connection.add(conn_type: str, options: Optional[ConnectionOptions] = None, ifname: str = "*", name: str = None, autoconnect: Bool = None) -> None
+                nmcli.connection.add("wifi", options, "*", network, True)
+            except Exception as ex_err: # pylint: disable=broad-exception-caught
+                oradio_log.error("Failed to add '%s' to NetworkManager, error = %s", network, ex_err)
+                return False
+
+    # Network is added or modified successfully
     return True
 
-def _networkmanager_remove(network):
+def _networkmanager_del(network):
     """
     Private function
     Remove given network from NetworkManager
@@ -452,10 +399,21 @@ def _networkmanager_remove(network):
         oradio_log.debug("Remove '%s' from NetworkManager", network)
         # nmcli.connection.delete(name: str, wait: int = None) -> None # Default timeout is 10 seconds
         nmcli.connection.delete(network)
-    except Exception as ex_err:       # pylint: disable=broad-exception-caught
+    except Exception as ex_err: # pylint: disable=broad-exception-caught
         oradio_log.error("Failed to remove '%s' from NetworkManager, error = %s", network, ex_err)
         return False
     return True
+
+def _networkmanager_restart():
+    """
+    Private function
+    Restart NetworkManager forces rescan and reconnect if a known wifi network is in range
+    """
+    cmd = "sudo systemctl restart NetworkManager"
+    result, response = run_shell_script(cmd)
+    if not result:
+        oradio_log.error("Error during <%s> to restart NetworkManager, error: %s", cmd, response)
+        # Return fail, so caller can try to recover
 
 # Entry point for stand-alone operation
 if __name__ == '__main__':
@@ -469,7 +427,7 @@ if __name__ == '__main__':
         If so, read the message from queue and display it
         :param queue = the queue to check for
         """
-        print("Listening for messages\n")
+        print("\nListening for messages")
 
         while True:
             # Wait for message
@@ -486,27 +444,27 @@ if __name__ == '__main__':
     message_listener.start()
 
     # Show menu with test options
-    INPUT_SELECTION = ("Select a function, input the number.\n"
+    INPUT_SELECTION = ("\nSelect a function, input the number.\n"
                        " 0-quit\n"
-                       " 1-get wifi state\n"
-                       " 2-list on air wifi networks\n"
-                       " 3-list wifi networks in NetworkManager\n"
-                       " 4-remove network from NetworkManager\n"
-                       " 5-get active wifi connection\n"
-                       " 6-connect to wifi network\n"
-                       " 7-start access point\n"
-                       " 8-disconnect from network\n"
+                       " 1-list wifi networks in NetworkManager\n"
+                       " 2-add network to NetworkManager\n"
+                       " 3-remove network from NetworkManager\n"
+                       " 4-restart NetworkManager\n"
+                       " 5-list on air wifi networks\n"
+                       " 6-get wifi state and connection\n"
+                       " 7-connect to wifi network\n"
+                       " 8-start access point\n"
+                       " 9-disconnect from network\n"
                        "select: "
                        )
 
     # User command loop
     while True:
-
         # Get user input
         try:
-            function_nr = int(input(INPUT_SELECTION))  # pylint: disable=invalid-name
+            function_nr = int(input(INPUT_SELECTION)) # pylint: disable=invalid-name
         except ValueError:
-            function_nr = -1  # pylint: disable=invalid-name
+            function_nr = -1 # pylint: disable=invalid-name
 
         # Execute selected function
         match function_nr:
@@ -514,38 +472,55 @@ if __name__ == '__main__':
                 print("\nExiting test program...\n")
                 break
             case 1:
-                print(f"\nWiFi state: {wifi.get_state()}\n")
+                print(f"\nNetworkManager wifi connections: {_networkmanager_list()}\n") # pylint: disable=protected-access
             case 2:
-                print(f"\nActive wifi networks: {get_wifi_networks()}\n")
-            case 3:
-                print(f"\nNetworkManager wifi connections: {_networkmanager_list()}\n")   # pylint: disable=protected-access
-            case 4:
-                network_id = input("Enter connection to remove from NetworkManager: ")
-                if network_id:
-                    print(f"\nRemoved {network_id} from NetworkManager: {_networkmanager_remove(network_id)}\n")
-                else:
-                    print("\nNo connection given\n")
-            case 5:
-                print(f"\nActive wifi connection: {get_wifi_connection()}\n")
-            case 6:
-                network_id = input("Enter SSID of the network to add: ")
+                name = input("Enter SSID of the network to add: ")
                 password = input("Enter password for the network to add (empty for open network): ")
-                if network_id:
-                    wifi.wifi_connect(network_id, password)
-                    if password:
-                        print(f"\nConnecting to '{network_id}' with password '{password}'. Check messages for result\n")
+                if name:
+                    if _networkmanager_add(name, password): # pylint: disable=protected-access
+                        print(f"\n{GREEN}'{name}' added to NetworkManager{NC}\n")
                     else:
-                        print(f"\nConnecting to '{network_id}' without password. Check messages for result\n")
+                        print(f"\n{RED}Failed to add '{name}' to NetworkManager{NC}\n")
                 else:
-                    print("\nNo network given\n")
+                    print(f"\n{YELLOW}No network given{NC}\n")
+            case 3:
+                name = input("Enter network to remove from NetworkManager: ")
+                if name:
+                    if _networkmanager_del(name): # pylint: disable=protected-access
+                        print(f"\n{GREEN}'{name}' deleted from NetworkManager{NC}\n")
+                    else:
+                        print(f"\n{RED}Failed to delete '{name}' from NetworkManager{NC}\n")
+                else:
+                    print(f"\n{YELLOW}No network given{NC}\n")
+            case 4:
+                print("\nRestart NetworkManager\n")
+                _networkmanager_restart() # pylint: disable=protected-access
+            case 5:
+                print(f"\nActive wifi networks: {get_wifi_networks()}\n")
+            case 6:
+                state = wifi.get_state()
+                if state == STATE_WIFI_IDLE:
+                    print(f"\nWiFi state: '{state}'\n")
+                else:
+                    print(f"\nWiFi state: '{state}'. Connected with: '{get_wifi_connection()}'\n")
             case 7:
+                name = input("Enter SSID of the network to add: ")
+                password = input("Enter password for the network to add (empty for open network): ")
+                if name:
+                    wifi.wifi_connect(name, password)
+                    print(f"\nConnecting with '{name}'. Check messages for result\n")
+                else:
+                    print(f"\n{YELLOW}No network given{NC}\n")
+            case 8:
                 print("\nStarting access point. Check messages for result\n")
                 wifi.wifi_connect(ACCESS_POINT_SSID, None)
-            case 8:
+                print(f"\nConnecting with '{ACCESS_POINT_SSID}'. Check messages for result\n")
+            case 9:
                 print("\nWiFi disconnected: check messages for result\n")
                 wifi.wifi_disconnect()
+                print(f"\nDisconnecting. Check messages for result\n")
             case _:
-                print("\nPlease input a valid number\n")
+                print(f"\n{YELLOW}Please input a valid number{NC}\n")
 
     # Stop listening to messages
     if message_listener:

--- a/Python/wifi_service.py
+++ b/Python/wifi_service.py
@@ -65,14 +65,8 @@ class WifiService():
         self.msg_q = queue
         self.saved = None
 
-        # Add access point credentials to NetworkManager
-        if not _networkmanager_add(ACCESS_POINT_SSID):
-            error = MESSAGE_WIFI_FAIL_CONFIG
-        else:
-            error = MESSAGE_NO_ERROR
-
         # Send initial state and error message
-        self._send_message(error)
+        self._send_message(MESSAGE_NO_ERROR)
 
     def _send_message(self, error):
         """
@@ -145,7 +139,6 @@ class WifiService():
         # Connecting takes time, can fail: offload to a separate thread
         # ==> Don't use reference so that the python interpreter can garbage collect when thread is done
         threading.Thread(target=self._wifi_connect_thread, args=(ssid,)).start()
-
         oradio_log.info("Connecting to '%s' started", ssid)
 
     def _wifi_connect_thread(self, network):
@@ -167,6 +160,9 @@ class WifiService():
                 err_msg = MESSAGE_WIFI_FAIL_START_AP
             else:
                 err_msg = MESSAGE_WIFI_FAIL_CONNECT
+            # Remove failed network from NetworkManager
+            # Ignore success/fail: err_msg is already FAIL
+            _networkmanager_del(network)
         else:
             oradio_log.info("Connected with '%s'", network)
 


### PR DESCRIPTION
Major overhaul of wifi service and web service:
- wifi service no longer manages only one single active wifi network connection, as we no longer need to know on which network the Oradio is connected (was required up to version 0.3.0 to find the web interface)
- Managing the access point OradioAP is now completely done in start/stop calls in web service
