### PR TITLE
Fix issue #313: show network name

### DIFF
--- a/Python/fastapi_server.py
+++ b/Python/fastapi_server.py
@@ -42,6 +42,7 @@ from mpd_control import get_mpd_control
 
 ##### GLOBAL constants ####################
 from oradio_const import (
+    YELLOW, NC,
     USB_SYSTEM,
     WEB_SERVER_HOST,
     WEB_SERVER_PORT,
@@ -310,8 +311,15 @@ async def network_page(request: Request):
         # Return fail, so caller can try to recover
         return JSONResponse(status_code=400, content={"message": response})
 
-    # Return network page with Spotify name as context
-    return templates.TemplateResponse(request=request, name="network.html", context={"spotify": response.strip()})
+    # Get the network Oradio was connected to before starting access point, empty string if None
+    oldssid = api_app.state.service.wifi.get_saved_network() or ""
+
+    # Return network page and saved wifi connection and spotify name as context
+    context = {
+                "oldssid" : oldssid,
+                "spotify" : response.strip()
+            }
+    return templates.TemplateResponse(request=request, name="network.html", context=context)
 
 # POST endpoint to get networks
 @api_app.post("/get_networks")

--- a/Python/templates/buttons.html
+++ b/Python/templates/buttons.html
@@ -368,8 +368,10 @@
 			<!-- Show Oradio logo -->
 			<img src="../static/logo.png" class="logo" />
 
-			<!-- Link playlists to presets -->
+			<!-- Manage presets title bar -->
 			<h1 id="presets">Speellijst aan knop koppelen</h1>
+
+			<!-- Link playlists to presets -->
 			{% for preset in presets %}
 				<div class="presets-grid">
 					<div class="preset-label">
@@ -383,13 +385,15 @@
 				</div>
 			{% endfor %}
 
-			<!-- Show notifcations, if any -->
+			<!-- Show notifcation, if any -->
 			<div id="presets_notification" class="notification">
 				<!-- Will be filled by Javascript -->
 			</div>
 
-			<!-- Manage playlists -->
+			<!-- Show playlist songs title bar -->
 			<h1 id="playlists">Liedjes van speellijst bekijken</h1>
+
+			<!-- Select playlist -->
 			<div class="playlists_grid">
 				<div class="custom-select">
 					<input type="text" id="playlist" name="playlist" readonly placeholder="-- Kies een speellijst --" />
@@ -398,7 +402,7 @@
 				</div>
 			</div>
 
-			<!-- Show notifcations, if any -->
+			<!-- Show notifcation, if any -->
 			<div id="playlist_notification" class="notification">
 				<!-- Will be filled by Javascript -->
 			</div>

--- a/Python/templates/network.html
+++ b/Python/templates/network.html
@@ -19,10 +19,12 @@
 		<script>
 			// Initialize
 			let networks = [];
+			let notification_oldssid;
 			let notification_network;
 			let notification_spotify;
 
 			// Convert template variable to javascript
+			const oldssid = {{ oldssid|tojson }};
 			const spotify = {{ spotify|tojson }};
 
 			// Function to get the active wifi networks
@@ -172,6 +174,9 @@
 
 				try
 				{
+					// Show waiting indicator as it will take a few seconds before the connection is lost
+					show_waiting();
+
 					// Send credentials to server
 					const response = await fetch('/wifi_connect',
 					{
@@ -200,6 +205,9 @@
 				{
 					notification_network.innerHTML = `<p class="error">${errorMessage}<br>Controleer of de web interface actief is</p>`;
 				}
+
+				// Hide the waiting indicator, showigg error messages, if any
+				hide_waiting();
 			}
 
 			// Function to submit the Spotify name
@@ -282,14 +290,23 @@
 				getNetworks();
 
 				// Get notifications
+				notification_oldssid = document.getElementById('notification_oldssid');
 				notification_network = document.getElementById('notification_network');
 				notification_spotify = document.getElementById('notification_spotify');
 
 				// Clear old notifications
+				notification_oldssid.innerHTML = "";
 				notification_network.innerHTML = "";
 				notification_spotify.innerHTML = "";
 
+				// Notify which network the Oradio was connected t obefore starting the web interface
+				if (oldssid == "")
+					notification_oldssid.innerHTML = `<p>Oradio was niet verbonden met een WiFi-netwerk</p>`;
+				else
+					notification_oldssid.innerHTML = `<p>Oradio was verbonden met WiFi-netwerk '${oldssid}'</p>`;
+
 				// Show notifications
+				notification_oldssid.style.display = "block";
 				notification_network.style.display = "block";
 				notification_spotify.style.display = "block";
 
@@ -348,8 +365,14 @@
 			<!-- Provide network credentials to connect to -->
 			<form onsubmit="submitCredentials(event)">
 
-				<!-- Network SSID -->
+				<!-- Network title bar -->
 				<h1 >Verbind Oradio met WiFi-netwerk</h1>
+
+				<div id="notification_oldssid" class="notification">
+					<!-- Will be filled by Javascript submitCredentials() -->
+				</div>
+
+				<!-- Network SSID -->
 				<label for="SSIDs">Netwerk:</label>
 				<div id="network" class="custom-select">
 					<input type="text" id="SSIDs" name="SSIDs" readonly placeholder="-- Selecteer of typ uw WiFi-netwerk --" />
@@ -367,21 +390,24 @@
 					<span class="password-toggle-icon oradio-eye"><i class="fa-regular fa-eye"></i></span>
 				</div>
 				<button id="submitCredentialsButton" type="submit" style="display: none">Met netwerk verbinden</button>
+
+				<!-- Show notifcation, if any -->
 				<div id="notification_network" class="notification">
 					<!-- Will be filled by Javascript submitCredentials() -->
 				</div>
 
 			</form>
 
-			<!-- Separator
-			<div style="height: 30px;">&nbsp;</div>
-			-->
-
 			<form onsubmit="submitSpotify(event)">
-				<!-- Spotify -->
+
+				<!-- Spotify title bar -->
 				<h1 >Kies naam in Spotify app</h1>
+
+				<!-- Spotify -->
 				<input id="spotify" type="text" value="{{ spotify }}" placeholder="Voer Spotify naam van deze Oradio in" />
 				<button id="submitSpotifyButton" type="submit">Spotify naam instellen</button>
+
+				<!-- Show notifcation, if any -->
 				<div id="notification_spotify" class="notification">
 					<!-- Will be filled by Javascript submitSpotify() -->
 				</div>

--- a/Python/templates/network.html
+++ b/Python/templates/network.html
@@ -197,6 +197,9 @@
 
 						// Notify
 						notification_network.innerHTML = `<p class="error">${errorData.message || errorMessage}</p>`;
+
+						// Error found: Hide the waiting indicator
+						hide_waiting();
 					}
 				}
 
@@ -204,10 +207,10 @@
 				catch (error)
 				{
 					notification_network.innerHTML = `<p class="error">${errorMessage}<br>Controleer of de web interface actief is</p>`;
-				}
 
-				// Hide the waiting indicator, showigg error messages, if any
-				hide_waiting();
+					// Error found: Hide the waiting indicator
+					hide_waiting();
+				}
 			}
 
 			// Function to submit the Spotify name
@@ -303,7 +306,7 @@
 				if (oldssid == "")
 					notification_oldssid.innerHTML = `<p>Oradio was niet verbonden met een WiFi-netwerk</p>`;
 				else
-					notification_oldssid.innerHTML = `<p>Oradio was verbonden met WiFi-netwerk '${oldssid}'</p>`;
+					notification_oldssid.innerHTML = `<p>Oradio was verbonden met '${oldssid}'</p>`;
 
 				// Show notifications
 				notification_oldssid.style.display = "block";

--- a/Python/templates/playlists.html
+++ b/Python/templates/playlists.html
@@ -672,9 +672,10 @@
 			<!-- Show Oradio logo -->
 			<img src="../static/logo.png" class="logo" />
 
-			<!-- Manage playlists -->
+			<!-- Manage playlist title bar -->
 			<h1 id="playlists">Speellijsten beheren</h1>
 
+			<!-- Manage playlists -->
 			<div class="playlists_grid">
 				<div class="custom-select">
 					<input type="text" id="autocomplete-input" placeholder="Typ hier de naam van de speellijst...">
@@ -684,7 +685,7 @@
 				<button class="delete-button-large" title="Verwijderen" onclick="removeSong()"></button>
 			</div>
 
-			<!-- Show notifcations, if any -->
+			<!-- Show notifcation, if any -->
 			<div id="playlist_notification" class="notification">
 				<!-- Will be filled by Javascript -->
 			</div>
@@ -695,12 +696,14 @@
 				</ul>
 			</div>
 
-			<!-- Search songs by artist or title -->
+			<!-- Search songs title bar -->
 			<h1 id="search_songs">Liedjes zoeken</h1>
+
+			<!-- Search songs by artist or title -->
 			<input style="margin: 0;" id="search" name="search" type="text" placeholder="Typ (deel van) naam van artiest of (deel van) titel" />
 			<button type="text" title="Zoeken" onclick="getSearchSongs()">Zoeken</button>
 
-			<!-- Show notifcations, if any -->
+			<!-- Show notifcation, if any -->
 			<div id="search_notification" class="notification">
 				<!-- Will be filled by Javascript -->
 			</div>

--- a/Python/web_service.py
+++ b/Python/web_service.py
@@ -41,8 +41,7 @@ from wifi_service import WifiService, get_wifi_connection
 
 ##### GLOBAL constants ####################
 from oradio_const import (
-#    RED,
-    GREEN, YELLOW, NC,
+    RED, GREEN, YELLOW, NC,
     ACCESS_POINT_HOST,
     ACCESS_POINT_SSID,
     STATE_WIFI_IDLE,
@@ -478,11 +477,12 @@ if __name__ == '__main__':
                 name = input("Enter SSID of the network to add: ")
                 pswrd = input("Enter password for the network to add (empty for open network): ")
                 if name:
-                    print("\nStarting the web service...\n")
-                    web_service.start()
                     print(f"\nConnecting with '{name}'. Check messages for result\n")
-                    url = "http://127.0.0.1:8000/wifi_connect" # pylint: disable=invalid-name
-                    requests.post(url, json={"ssid": name, "pswd": pswrd}, timeout=TIMEOUT)
+                    url = f"http://{WEB_SERVER_HOST}:{WEB_SERVER_PORT}/wifi_connect" # pylint: disable=invalid-name
+                    try:
+                        requests.post(url, json={"ssid": name, "pswd": pswrd}, timeout=TIMEOUT)
+                    except: # pylint: disable=bare-except
+                        print(f"{RED}Failed to requestr server to start a connection. Make sure you have an active web server{NC}\n")
                 else:
                     print(f"\n{YELLOW}No network given{NC}\n")
             case 6:

--- a/Python/wifi_service.py
+++ b/Python/wifi_service.py
@@ -104,7 +104,7 @@ class WifiService():
         # Connection to wifi network WITHOUT internet access
         return STATE_WIFI_CONNECTED
 
-    def get_saved_wifi(self):
+    def get_saved_network(self):
         """
         Public function
         Return the ssid of the last wifi connection


### PR DESCRIPTION
When Oradio was connected to wifi when starting the captive portal you can now see which network the Oradio was connected to 
When submitting the network credentials a waiting indicator is added