### PR TITLE
Update USB_sync.sh

### DIFF
--- a/tools/USB_sync.sh
+++ b/tools/USB_sync.sh
@@ -148,13 +148,10 @@ function cleanup {
 	local signal="${1:-EXIT}"	# trap signal: EXIT, INT, TERM
 	local exitcode="${2:-0}"	# optional exit code for EXIT
 
-#    # Reset terminal
-#    stty sane
-    # Reset terminal (only if attached to a TTY)
+    # Reset terminal if attached to a TTY
     if [ -t 0 ]; then
         stty sane
     fi
-
 
 	# Skip if cleanup already ran
 	if $CLEANUP_DONE; then


### PR DESCRIPTION
When the ssh session stops, the USB_sync does not stop, and will keep running until sync is finshed