### PR TITLE
Clear MPD on power on

### DIFF
--- a/install_resources/mpd.service
+++ b/install_resources/mpd.service
@@ -10,6 +10,9 @@ EnvironmentFile=/etc/default/mpd
 # Force use of /etc/mpd.conf
 ExecStart=/usr/bin/mpd --systemd /etc/mpd.conf
 
+# Run mpc clear after MPD has started
+ExecStartPost=/usr/bin/mpc clear
+
 # Enable this setting to ask systemd to watch over MPD, see
 # systemd.service(5).  This is disabled by default because it causes
 # periodic wakeups which are unnecessary if MPD is not playing.


### PR DESCRIPTION
Fix issue #392: When MPD service is started its state is cleared, so the Oradio always starts in the same way after a power cycle.