### PR TITLE
KEEP_ALIVE_TIMEOUT patch

### DIFF
--- a/Python/fastapi_server.py
+++ b/Python/fastapi_server.py
@@ -67,7 +67,7 @@ INFO_ERROR    = {"serial": "undefined", "version": "undefined"}
 # Location of version info
 SOFTWARE_VERSION_FILE = "/var/log/oradio_sw_version.log"
 # Stop server if no keep alive message received, in seconds
-KEEP_ALIVE_TIMEOUT = 5
+KEEP_ALIVE_TIMEOUT = 30
 
 # Initialise MPD client
 mpd_control = MPDControl()


### PR DESCRIPTION
Change KEEP_ALIVE_TIMEOUT from 5 to 30 seconds to prevent a slow web server to unintentionally stop