### PR TITLE
Fix #437 - OradioAP stops unexpectedly

### DIFF
--- a/Python/fastapi_server.py
+++ b/Python/fastapi_server.py
@@ -534,7 +534,11 @@ async def stop_task():
 @api_app.post("/keep_alive")
 async def keep_alive():
     """Handle POST request to (re)set the inactive timer for closing the web server."""
-    oradio_log.debug("Starting/resetting the keep alive timer")
+    if api_app.state.timer_deadline is None:
+        oradio_log.debug("Starting the keep alive timer")
+    else:
+        remaining = (api_app.state.timer_deadline - datetime.utcnow()).total_seconds()
+        oradio_log.debug("Time remaining: %f. Resetting the keep alive timer", remaining)
 
     # Set the new deadline
     api_app.state.timer_deadline = datetime.utcnow() + timedelta(seconds=KEEP_ALIVE_TIMEOUT)


### PR DESCRIPTION
### Address issue #437:
- Every incoming request:
   - Stops the timeout timer (if active),
   - Handles the request,
   - Starts the timer only after a web interface request
- For debugging logs the remaining time when the timeout timer is reset

**NOTE**: timeout is set to 5 seconds, keep-alive requests come every 2 seconds. 
So the client has some 'safety margin' to send the keep alive request, and 
the server will shutdown if it does not receive a keep-alive request for more than 5 seconds.